### PR TITLE
[SWAR] Add greaterEqual for sublane abstraction and an msb-on version that blits out alternate sublanes.

### DIFF
--- a/inc/zoo/meta/BitmaskMaker.h
+++ b/inc/zoo/meta/BitmaskMaker.h
@@ -40,15 +40,22 @@ struct BitmaskMaker {
         >::value;
 };
 
-/// Provides TopBlit to clear any garbage bits at the top of a bitmask made by
-//BitmaskMaker
-template<typename T, int CurrentSize>
+/// Provides TopBlit mask to clear any garbage bits at the top of a bitmask
+/// made by BitmaskMaker.
+/// \tparam T the desired integral type
+/// \tparam PatternBitCount the width of the pattern, repeating. So 32 bits
+///   with a 12 bit PatternBitCount results in a TopBlit with 6 bit top clear.
+template<typename T, int PatternBitCount>
 struct BitmaskMakerClearTop {
     constexpr static T BitCount = sizeof(T)*8;
-    constexpr static T LeastBitKeepCount = BitCount - BitCount % CurrentSize;
-    constexpr static T BitMod = BitCount % CurrentSize;
-    constexpr static T TopBlit = (BitMod == 0) ? ~(T(0)) :
-        ((T(1) << LeastBitKeepCount) -1);
+    constexpr static T BitCountRemainder = BitCount % PatternBitCount;
+    constexpr static T LeastBitsKeepCount =
+        BitCount - BitCount % PatternBitCount;
+    constexpr static T BitMod = BitCount % PatternBitCount;
+    constexpr static T TopBlit = 
+        BitMod == 0 ? 
+            ~(T(0)) :
+            ((T(1) << LeastBitsKeepCount) -1);
 };
 
 static_assert(0xFF == BitmaskMaker<uint8_t, 0x7, 3>::value);

--- a/inc/zoo/meta/BitmaskMaker.h
+++ b/inc/zoo/meta/BitmaskMaker.h
@@ -40,16 +40,15 @@ struct BitmaskMaker {
         >::value;
 };
 
-/// Provides TopBlit to clear any garbage bits at the top of a bitmask made by BitmaskMaker
+/// Provides TopBlit to clear any garbage bits at the top of a bitmask made by
+//BitmaskMaker
 template<typename T, int CurrentSize>
 struct BitmaskMakerClearTop {
-    // To ensure 0s above CurrentSize
-    constexpr static T Eight = 8;
-    constexpr static T Zero = 0;
-    constexpr static T BitCount = sizeof(T)*Eight;
+    constexpr static T BitCount = sizeof(T)*8;
     constexpr static T LeastBitKeepCount = BitCount - BitCount % CurrentSize;
     constexpr static T BitMod = BitCount % CurrentSize;
-    constexpr static T TopBlit = (BitMod == 0) ? ~(T(0)) : ((T(1) << LeastBitKeepCount) -1);
+    constexpr static T TopBlit = (BitMod == 0) ? ~(T(0)) :
+        ((T(1) << LeastBitKeepCount) -1);
 };
 
 static_assert(0xFF == BitmaskMaker<uint8_t, 0x7, 3>::value);

--- a/inc/zoo/meta/BitmaskMaker.h
+++ b/inc/zoo/meta/BitmaskMaker.h
@@ -40,8 +40,21 @@ struct BitmaskMaker {
         >::value;
 };
 
+/// Provides TopBlit to clear any garbage bits at the top of a bitmask made by BitmaskMaker
+template<typename T, int CurrentSize>
+struct BitmaskMakerClearTop {
+    // To ensure 0s above CurrentSize
+    constexpr static T Eight = 8;
+    constexpr static T Zero = 0;
+    constexpr static T BitCount = sizeof(T)*Eight;
+    constexpr static T LeastBitKeepCount = BitCount - BitCount % CurrentSize;
+    constexpr static T BitMod = BitCount % CurrentSize;
+    constexpr static T TopBlit = (BitMod == 0) ? ~(T(0)) : ((T(1) << LeastBitKeepCount) -1);
+};
+
+static_assert(0xFF == BitmaskMaker<uint8_t, 0x7, 3>::value);
 static_assert(0xF0F0 == BitmaskMaker<uint16_t, 0xF0, 8>::value);
-static_assert(0xEDFEDFED == BitmaskMaker<uint32_t, 0xFED, 12>::value);
+static_assert(0xEDFE'DFED == BitmaskMaker<uint32_t, 0xFED, 12>::value);
 
 }} // zoo::meta
 

--- a/inc/zoo/swar/SWAR.h
+++ b/inc/zoo/swar/SWAR.h
@@ -107,12 +107,21 @@ template<int NBitsMost, int NBitsLeast, typename T = uint64_t> struct SWARWithSu
     using Base = swar::SWAR<LaneBits, T>;
 
     //constexpr T Ones = meta::BitmaskMaker<NBits, SWAR<NBits, T>{1}.value(), T>::value;
-    static constexpr inline auto TopBlit = meta::BitmaskMakerClearTop<T, LaneBits>::TopBlit;
-    static constexpr inline auto LeastOnes = meta::BitmaskMaker<T, Base{1}.value(), LaneBits>::value & TopBlit;
-    static constexpr inline auto MostOnes = meta::BitmaskMaker<T, Base{1<<NBitsLeast}.value(), LaneBits>::value & TopBlit;
-    static constexpr inline auto MostMostOnes = meta::BitmaskMaker<T, Base{1<<(LaneBits-1)}.value(), LaneBits>::value & TopBlit;
-    static constexpr inline auto LeastMask = meta::BitmaskMaker<T, Base{~(~0ull<<NBitsLeast)}.value(), LaneBits>::value & TopBlit;
-    static constexpr inline auto MostMask = ~LeastMask & TopBlit;
+    static constexpr inline auto TopBlit =
+        meta::BitmaskMakerClearTop<T, LaneBits>::TopBlit;
+    static constexpr inline auto LeastOnes =
+        meta::BitmaskMaker<T, Base{1}.value(), LaneBits>::value & TopBlit;
+    static constexpr inline auto MostOnes =
+        meta::BitmaskMaker<T, Base{1<<NBitsLeast}.value(), LaneBits>::value &
+        TopBlit;
+    static constexpr inline auto MostMostOnes =
+        meta::BitmaskMaker<T, Base{1<<(LaneBits-1)}.value(), LaneBits>::value &
+        TopBlit;
+    static constexpr inline auto LeastMask =
+        meta::BitmaskMaker<T, Base{~(~0ull<<NBitsLeast)}.value(), LaneBits>::value &
+        TopBlit;
+    static constexpr inline auto MostMask =
+        ~LeastMask & TopBlit;
 
     constexpr auto least() const noexcept {
         return this->m_v & LeastMask;

--- a/inc/zoo/swar/SWAR.h
+++ b/inc/zoo/swar/SWAR.h
@@ -107,10 +107,12 @@ template<int NBitsMost, int NBitsLeast, typename T = uint64_t> struct SWARWithSu
     using Base = swar::SWAR<LaneBits, T>;
 
     //constexpr T Ones = meta::BitmaskMaker<NBits, SWAR<NBits, T>{1}.value(), T>::value;
-    static constexpr inline auto LeastOnes = meta::BitmaskMaker<T, Base{1}.value(), LaneBits>::value;
-    static constexpr inline auto MostOnes = meta::BitmaskMaker<T, Base{1<<NBitsLeast}.value(), LaneBits>::value;
-    static constexpr inline auto LeastMask = meta::BitmaskMaker<T, Base{~(~0ull<<NBitsLeast)}.value(), LaneBits>::value;
-    static constexpr inline auto MostMask = ~LeastMask;
+    static constexpr inline auto TopBlit = meta::BitmaskMakerClearTop<T, LaneBits>::TopBlit;
+    static constexpr inline auto LeastOnes = meta::BitmaskMaker<T, Base{1}.value(), LaneBits>::value & TopBlit;
+    static constexpr inline auto MostOnes = meta::BitmaskMaker<T, Base{1<<NBitsLeast}.value(), LaneBits>::value & TopBlit;
+    static constexpr inline auto MostMostOnes = meta::BitmaskMaker<T, Base{1<<(LaneBits-1)}.value(), LaneBits>::value & TopBlit;
+    static constexpr inline auto LeastMask = meta::BitmaskMaker<T, Base{~(~0ull<<NBitsLeast)}.value(), LaneBits>::value & TopBlit;
+    static constexpr inline auto MostMask = ~LeastMask & TopBlit;
 
     constexpr auto least() const noexcept {
         return this->m_v & LeastMask;
@@ -144,13 +146,13 @@ template<int NBitsMost, int NBitsLeast, typename T = uint64_t> struct SWARWithSu
         return most(pos) >> (LaneBits*pos)>> NBitsLeast;
     }
 
-    // Blits most sig bits into least significant bits. Experimental.
-    constexpr auto flattenMostToLeast(u32 pos) const noexcept {
+    // Shifts most sig bits into least significant bits. Experimental.
+    constexpr auto flattenMostToLeast() const noexcept {
         return (this->m_v >> NBitsLeast) & LeastMask;
     }
 
-    // Blits least sig bits into most significant bits. Experimental.
-    constexpr auto promoteLeastToMost(u32 pos) const noexcept {
+    // Shifts least sig bits into most significant bits. Experimental.
+    constexpr auto promoteLeastToMost() const noexcept {
         return (this->m_v << NBitsMost) & MostMask;
     }
 
@@ -266,8 +268,43 @@ struct BooleanSWAR: SWAR<NBits, T> {
 
 };
 
+// Only works for NBits <= sizeof(T)*8/2
 template<int NBits, typename T>
-constexpr BooleanSWAR<NBits, T> greaterEqual_MSB_off(SWAR<NBits, T> left, SWAR<NBits, T> right) noexcept {
+constexpr BooleanSWAR<NBits, T> greaterEqual_laneblit(
+        SWAR<NBits, T> left, 
+        SWAR<NBits, T> right) noexcept {
+    // Think of blitting out alternate lanes, then shifting them down to the
+    // least significant bits of a swar with double-width lanes, then doing an
+    // msb-off subtract as usual, then shifting the least bits boolean compare
+    // result down to their original lane, then blitting them back together.
+    constexpr auto DoubleNBits = NBits * 2;
+    constexpr auto MLMSB = BooleanSWAR<NBits, T>::maskLaneMSB;
+    constexpr auto DoubleMLMSB = BooleanSWAR<DoubleNBits, T>::maskLaneMSB;
+    constexpr auto MaskPattern = leastNBitsMask<NBits, T>() << NBits;
+    constexpr auto MostHalfMask =
+        meta::BitmaskMaker<T, MaskPattern, DoubleNBits>::value;
+    constexpr auto LeastHalfMask = ~MostHalfMask;
+
+    const auto leastHalfLeft = left.value() & LeastHalfMask;
+    const auto leastHalfRight = right.value() & LeastHalfMask;
+    const auto highHalfLeft = (left.value() & MostHalfMask) >> NBits;
+    const auto highHalfRight = (right.value() & MostHalfMask) >> NBits;
+    const auto leastHalfCompareShifted =
+        ((leastHalfLeft | DoubleMLMSB) - leastHalfRight) & DoubleMLMSB;
+    // results are in high bits, so shift result of least compare down.
+    const auto leastHalfCompare = leastHalfCompareShifted >> NBits;
+
+    // Most half has to shift down to compare safely
+    const auto highHalfCompareShifted =
+        ((highHalfLeft | DoubleMLMSB) - highHalfRight) & DoubleMLMSB;
+    const auto highHalfCompare = highHalfCompareShifted;
+    const auto final = highHalfCompare | leastHalfCompare;
+    return BooleanSWAR<NBits, T>{ final};
+}
+
+template<int NBits, typename T>
+constexpr BooleanSWAR<NBits, T> greaterEqual_MSB_off(
+        SWAR<NBits, T> left, SWAR<NBits, T> right) noexcept {
     constexpr auto MLMSB = BooleanSWAR<NBits, T>::maskLaneMSB;
     // TODO(scottbruceheart) operator- and others on SWAR to avoid using .value here.
     return SWAR<NBits, T>{
@@ -275,10 +312,12 @@ constexpr BooleanSWAR<NBits, T> greaterEqual_MSB_off(SWAR<NBits, T> left, SWAR<N
     };
 }
 
+
 template<int N, int NBits, typename T>
 constexpr BooleanSWAR<NBits, T> greaterEqual(SWAR<NBits, T> v) noexcept {
     static_assert(1 < NBits, "Degenerated SWAR");
-    //static_assert(meta::logCeiling(N) < NBits, "N is too big for this technique");  // ctzll isn't constexpr.
+    // ctzll isn't constexpr.
+    //static_assert(meta::logCeiling(N) < NBits, "N is too big for this technique");
     constexpr auto msbPosition  = NBits - 1;
     constexpr auto msb = T(1) << msbPosition;
     constexpr auto msbMask = meta::BitmaskMaker<T, msb, NBits>::value;
@@ -289,6 +328,30 @@ constexpr BooleanSWAR<NBits, T> greaterEqual(SWAR<NBits, T> v) noexcept {
     return BooleanSWAR<NBits, T>(rv);
 }
 
+template<int NBitsMost, int NBitsLeast, typename T = uint64_t>
+constexpr BooleanSWAR<NBitsMost + NBitsLeast, T> greaterEqualLeast(
+    SWARWithSubLanes<NBitsMost, NBitsLeast, T> left, 
+    SWARWithSubLanes<NBitsMost, NBitsLeast, T> right) noexcept {
+    using Sub = SWARWithSubLanes<NBitsMost, NBitsLeast, T>; 
+    constexpr auto MLMSB = BooleanSWAR<NBitsMost+NBitsLeast, T>::maskLaneMSB;
+    // Using the sublane abstraction allows direct subtract comparison between
+    // left and right, as we are certain msb will be off once we call 'least'.
+    // Set the most sig bit to 1 to make the subtract carry work.
+    return BooleanSWAR<NBitsMost+NBitsLeast,T>(
+        ((left.least() | Sub::MostMostOnes) - right.least()) & MLMSB);
+}
+
+// Only correct when NBitsMost >= NBitsLeast. Not 100% tested.
+template<int NBitsMost, int NBitsLeast, typename T = uint64_t>
+constexpr BooleanSWAR<NBitsMost + NBitsLeast, T> greaterEqualMost(
+    SWARWithSubLanes<NBitsMost, NBitsLeast, T> left, 
+    SWARWithSubLanes<NBitsMost, NBitsLeast, T> right) noexcept {
+    return greaterEqualLeast<NBitsMost, NBitsLeast, T>(
+        SWARWithSubLanes<NBitsMost, NBitsLeast, T>(left.flattenMostToLeast()), 
+        SWARWithSubLanes<NBitsMost, NBitsLeast, T>(right.flattenMostToLeast()));
+}
+
+
 /*
 This is just a draft implementation:
 1. The isolator needs pre-computing instead of adding 3 ops per iteration
@@ -298,7 +361,8 @@ This is just a draft implementation:
 template<int NBits, typename T>
 constexpr SWAR<NBits, T> logarithmFloor(SWAR<NBits, T> v) noexcept {
     constexpr auto LogNBits = meta::logFloor(NBits);
-    static_assert(NBits == (1 << LogNBits), "Logarithms of element width not power of two is un-implemented");
+    static_assert(NBits == (1 << LogNBits),
+        "Logarithms of element width not power of two is un-implemented");
     auto whole = v.value();
     auto isolationMask = BooleanSWAR<NBits, T>::maskLaneMSB;
     for(auto groupSize = 1; groupSize < NBits; groupSize <<= 1) {

--- a/test/swar/BasicOperations.cpp
+++ b/test/swar/BasicOperations.cpp
@@ -57,8 +57,12 @@ TEST_CASE(
 // Bitmasks.
 static_assert(0xFF == zoo::meta::BitmaskMaker<uint8_t, 0x7, 3>::value);
 static_assert(0x92 == zoo::meta::BitmaskMaker<uint8_t, 0x2, 3>::value);
-static_assert(0x3F == (zoo::meta::BitmaskMaker<uint8_t, 0x7, 3>::value & zoo::meta::BitmaskMakerClearTop<uint8_t, 3>::TopBlit));
-static_assert(0x12 == (zoo::meta::BitmaskMaker<uint8_t, 0x2, 3>::value & zoo::meta::BitmaskMakerClearTop<uint8_t, 3>::TopBlit));
+static_assert(0x3F == 
+    (zoo::meta::BitmaskMaker<uint8_t, 0x7, 3>::value &
+     zoo::meta::BitmaskMakerClearTop<uint8_t, 3>::TopBlit));
+static_assert(0x12 == 
+    (zoo::meta::BitmaskMaker<uint8_t, 0x2, 3>::value &
+     zoo::meta::BitmaskMakerClearTop<uint8_t, 3>::TopBlit));
 static_assert(0x00FE'DFED == (
     zoo::meta::BitmaskMaker<uint32_t, 0xFED, 12>::value  &
     zoo::meta::BitmaskMakerClearTop<uint32_t, 12>::TopBlit));
@@ -182,7 +186,8 @@ static_assert(0x0808'0808 == u32(broadcast<8>(SWAR<8, u32>(0x0000'0008))));
 static_assert(0x0B0B'0B0B == u32(broadcast<8>(SWAR<8, u32>(0x0000'000B))));
 static_assert(0x0E0E'0E0E == u32(broadcast<8>(SWAR<8, u32>(0x0000'000E))));
 static_assert(0x6B6B'6B6B == u32(broadcast<8>(SWAR<8, u32>(0x0000'006B))));
-static_assert(0x0808'0808'0808'0808ull == u64(broadcast<8>(SWAR<8, u64>(0x0000'0000'0000'0008ull))));
+static_assert(0x0808'0808'0808'0808ull ==
+    u64(broadcast<8>(SWAR<8, u64>(0x0000'0000'0000'0008ull))));
 
 static_assert(2 == lsbIndex(1<<1));
 static_assert(4 == lsbIndex(1<<3));
@@ -199,7 +204,8 @@ static_assert(0x80000000 == greaterEqual<7>(SWAR<4, uint32_t>(0x7654'3210)).valu
 
 
 // Unusual formatting for easy visual verification.
-#define GE_MSB_TEST(left, right, result) static_assert(result== greaterEqual_MSB_off<4, u32>(SWAR<4, u32>(left), SWAR<4, u32>(right)).value());
+#define GE_MSB_TEST(left, right, result) static_assert(result == \
+    greaterEqual_MSB_off<4, u32>(SWAR<4, u32>(left), SWAR<4, u32>(right)).value());
 
 GE_MSB_TEST(0x1000'0010,
             0x0111'1101,
@@ -251,7 +257,8 @@ GE_LEAST_TEST(0x0011'2233,
               0x4859'56EF,
               0x8888'8888)
 
-#define GE_MOST_TEST(left, right, result) static_assert(result == greaterEqualMost<2,2, u32>(Sub22u32(left), Sub22u32(right)).value());
+#define GE_MOST_TEST(left, right, result) static_assert(result == \
+    greaterEqualMost<2,2, u32>(Sub22u32(left), Sub22u32(right)).value());
 
 GE_MOST_TEST(0x0000'0000,
              0x0000'0000,
@@ -270,7 +277,8 @@ GE_MOST_TEST(0x4000'0040,
              0x8888'8888)
 
 #define GE_LEAST_VS_MSBOFF_TEST(left, right) static_assert( \
-    greaterEqual_MSB_off<4, u32>(SWAR4u32(Sub22u32(left).least()), SWAR4u32(Sub22u32(right).least())).value() ==  \
+    greaterEqual_MSB_off<4, u32>(SWAR4u32(Sub22u32(left).least()), \
+        SWAR4u32(Sub22u32(right).least())).value() ==  \
     greaterEqualLeast<2,2, u32>(Sub22u32(left), Sub22u32(right)).value());
 
 GE_LEAST_VS_MSBOFF_TEST(0x1000'0010,
@@ -282,7 +290,8 @@ GE_LEAST_VS_MSBOFF_TEST(0x8484'2151,
 GE_LEAST_VS_MSBOFF_TEST(0x0011'2233,
                         0x4859'56EF)
 
-#define GE_LEAST_BLIT(left, right, result) CHECK(result == greaterEqual_laneblit<4, u32>(SWAR4u32(left), SWAR4u32(right)).value());
+#define GE_LEAST_BLIT(left, right, result) CHECK(result == \
+    greaterEqual_laneblit<4, u32>(SWAR4u32(left), SWAR4u32(right)).value());
 
 TEST_CASE(
     "LaneBlit4",
@@ -310,7 +319,8 @@ GE_LEAST_BLIT(0xEF44'44FE,
               0x0888'8880)
 }
 
-#define GE_LEAST_BLIT12(left, right, result) CHECK(result == greaterEqual_laneblit<12, u32>(SWAR12u32(left), SWAR12u32(right)).value());
+#define GE_LEAST_BLIT12(left, right, result) CHECK(result == \
+    greaterEqual_laneblit<12, u32>(SWAR12u32(left), SWAR12u32(right)).value());
 
 TEST_CASE(
     "LaneBlit12",


### PR DESCRIPTION
Add 3 greaterEqual functions.
One operates on a swar that might have msb of each lane set to do compares. Blits swar<4> like 0x4444'4444 into 2 swar<8> like 0x4040'4040 and 0x0404'0404, shifts most-sig one to low lane, does compare, shifts low result down to low position, blits back together.
One operates on least lanes of a SWARWithSublanes.
One operates on most lanes of a SWARWithSublanes.