### PR TITLE
[robinhood][swar] Alt RH finds and related blocks, simple test for alt constructions.

### DIFF
--- a/inc/zoo/map/RobinHoodAlt.h
+++ b/inc/zoo/map/RobinHoodAlt.h
@@ -1,0 +1,194 @@
+
+#pragma once
+
+#include "zoo/swar/SWAR.h"
+
+#include <array>
+#include <cstddef>
+
+namespace zoo {
+
+namespace rh {
+
+using u64 = uint64_t;
+using u32 = uint32_t;
+using u16 = uint16_t;
+using u8 = uint8_t;
+
+template<int NBitsHash, int NBitsPSL, typename T = u64> struct SlotOperations {
+    using SSL = swar::SWARWithSubLanes<NBitsHash, NBitsPSL, T>;
+    using SM = swar::SWAR<NBitsHash + NBitsPSL, T>;
+    using BoolSM = swar::BooleanSWAR<NBitsHash + NBitsPSL, T>;
+    static constexpr inline auto SlotOnes =
+        meta::BitmaskMaker<T, SM{1}.value(), NBitsHash + NBitsPSL>::value;
+    // for 64 bit size, 8 bit meta, 0x0807'0605'0403'0201ull
+    static constexpr inline auto PSLProgression = SlotOnes * SlotOnes;
+    static constexpr T allOnes =
+        meta::BitmaskMaker<T, 1, NBitsHash+NBitsPSL>::value;
+
+    static constexpr auto needlePSL(T currentPSL) {
+        return broadcast(SM{currentPSL}) + SM{PSLProgression};
+    }
+
+    // At the position the needle psl exceeds the haystack psl, a match becomes
+    // impossible. Only elements _before_ the exceeding element can match.
+    // pslNeedle must be PSLProgression + startingPSLValue
+    static constexpr auto deadline(SM pslHaystack, SM pslNeedle) {
+        // We must ensure the MSBs of the psl blocks are off. Since we store
+        // PSLs in a swar with sublanes in the least bits, this guarantee
+        // holds.
+        auto satisfied = greaterEqual_MSB_off(pslHaystack, pslNeedle);
+        auto broken = not satisfied;
+        return swar::isolateLSB(broken.value());
+    }
+
+    // Has no intrinsic binding to the metadata, just easier to write with
+    // using decls.
+    static constexpr auto attemptMatch(
+             SM haystack, SM needleHashes, SM needlePSL) {
+        const auto haystackPSL = SM{SSL::LeastMask & haystack.value()};
+        const auto d = deadline(haystackPSL, needlePSL);  // breaks abstraction
+        const auto needle = needleHashes | needlePSL;
+
+        const auto matches = equals(haystack, needle);
+        const auto searchEnds = d ? 1 : 0; 
+        // Returned value is MSB boolean array with 'finality' bit on at
+        // position 0. Breaks if PSLs are width 1 (but so does everything else)
+        return SM{searchEnds | ((d - 1) & matches.value())};
+    }
+};
+
+/// Slot metadata provides the affordances of 
+///     'attempt to match this needle of hashes and PSLs'
+/// Contains sizeof(T)/(NBitsHash,NBitsPSL) hashes and PSLs
+template<int NBitsHash, int NBitsPSL, typename T = u64> struct SlotMetadata {
+    using SSL = swar::SWARWithSubLanes<NBitsHash, NBitsPSL, T>;
+    using SM = swar::SWAR<NBitsHash + NBitsPSL, T>;
+    using BoolSM = swar::BooleanSWAR<NBitsHash + NBitsPSL, T>;
+    // PSL are stored in least sig bits, Hashes are stored in most sig bits.
+    // This allows us to do fast greaterequal checks for PSLs (with the hashes
+    // blitted out) and fast equality checks for hash bits (as equality checks
+    // do not need carry bits.
+    SSL data_;
+
+    constexpr auto PSLs() const noexcept{
+        return data_.least();
+    }
+
+    constexpr auto Hashes() const noexcept {
+        return data_.most();
+    }
+
+    constexpr auto attemptMatch(SM needleHashes, SM needlePSL) {
+        return SlotOperations<NBitsHash, NBitsPSL, T>::attemptMatch(
+              data_, needleHashes, needlePSL);
+    }
+};
+
+/// BlockProvider provides affordances of
+///     'give me the slot metadata that contains position p'
+///     'set slot metadata at index that contains position p'
+///     'set key at position p'
+///     'check this concrete key against position p'
+template<int NBitsHash, int NBitsPSL, int Size, typename T = u64, typename Key = u64> struct SlotSplitKeys {
+    using SSL = swar::SWARWithSubLanes<NBitsHash, NBitsPSL, T>;
+    using SM = swar::SWAR<NBitsHash+ NBitsPSL, T>;
+    using BoolSM = swar::BooleanSWAR<NBitsHash+ NBitsPSL, T>;
+
+    std::array<Key,Size > keys_;
+    std::array<T, Size/SM::Lanes> metadata_;
+    
+    Key keyAt(int pos) const {
+      return keys_[pos];
+    }
+    void setKey(int pos, Key k) {
+      keys_[pos] = k;
+    }
+    constexpr int posToSlot(int pos) const { return pos/SM::Lanes; }
+    void setSlotAt(int idx, T v) {
+       metadata_[idx] = v;
+    }
+
+    // Track to avoid second divide?
+    SSL slotAt(int pos) const { return metadata_[posToSlot(pos)]; }
+    bool keyCheck(int major, int minor, Key k) const { return k == keyAt(major * SM::Lanes + minor); }
+    bool keyCheck(int pos, Key k) const { return k == keyAt(pos); }
+};
+
+/// RobinHood tables provide affordances of
+///     'lookup this key'
+///     'insert this key'
+///     'delete this key'
+/// Split locale of key value when both are present.
+/// Position is major + minor
+
+template<typename Key> 
+struct Hasher {
+    Key operator()(Key k) { return k; }
+};
+
+template<int NBitsHash, int NBitsPSL, int Size, typename Meta, typename T = u64, typename Key = u64, typename Hash = Hasher<Key>> 
+struct RH {
+    using SSL = swar::SWARWithSubLanes<NBitsHash, NBitsPSL, T>;
+    using SM = swar::SWAR<NBitsHash+ NBitsPSL, T>;
+    using BoolSM = swar::BooleanSWAR<NBitsHash+ NBitsPSL, T>;
+    Meta m_;
+    Hash h_;
+
+    bool exists(Key k) {
+      return findSlot(k).second;
+    }
+
+    struct MajorMinorInserted {
+        int major;
+        int minor;
+        bool inserted;
+    };
+
+    /// pos, hash
+    std::pair<u32, T> twoNumbers(Key k) {
+        auto hash = h_(k);
+        const u32 pos = mapToSlotLemireReduction<Size, T>(fibhash<Key, T>(hash));
+        const T thinhash = badMixer<NBitsHash> (hash);
+        return {pos, thinhash};
+    }
+
+    std::pair<u32, T> twoNumbersBad(Key k) {
+        return {1, 1};
+    }
+
+    /// Find slot can mean 'psl too short/no slot', 'found and in slot', 'not found but (richer|empty) slot'
+    /// Currently bug: 'psl too short/no slot' not handled correctly.
+    /// Returns major/minor to attempt to avoid divisions.
+    template <typename KeyCheck> 
+    MajorMinorInserted findSlot(Key k, KeyCheck kc) {
+      const auto twoNum = twoNumbersBad(k);
+      const auto pos = twoNum.first;
+      const auto hash = twoNum.second;
+      const auto major = m_.posToSlot(pos);
+      const auto haystack = m_.slotAt(pos);
+      // PSL is off by one territory
+      constexpr auto exactlyOne = SM{1};
+      auto minor = 0;
+      while(true) {
+          const auto matchResult = SlotOperations<NBitsHash, NBitsPSL, T>::matchAttempt(haystack, hash, 0);
+          auto finished = exactlyOne & matchResult;
+          auto matches = exactlyOne & ~matchResult;
+          while (matches) {
+              auto minor = matches.lsbIndex();  // Lane offset
+              if (m_.keyCheck(major + minor, k)) { 
+                  return {major, minor, true};  // 'found and in slot'
+              }
+              matches = SM{matches.clearLSB()};
+          }
+          // minor points at slot that the key currently fits in.
+          if (finished) {
+              return {major, minor, false};  // 'not found, richer or empty slot'
+          }
+      }
+    }
+};
+
+
+} // namespace rh
+} // namespace zoo

--- a/inc/zoo/map/RobinHoodUtil.h
+++ b/inc/zoo/map/RobinHoodUtil.h
@@ -123,6 +123,20 @@ constexpr auto fibonacciIndexModulo(T index) {
     return index * MagicalConstant;
 }
 
+// Key needs to change to an integer.
+template<typename Key, typename T = u64> T fibhash(Key k) noexcept {
+    constexpr std::array<uint64_t, 4>
+        GoldenRatioReciprocals = {
+            159,
+            40503,
+            2654435769,
+            11400714819323198485ull,
+        };
+    constexpr T GoldenConstant =
+        T(GoldenRatioReciprocals[meta::logFloor(sizeof(T)) - 3]);
+    return k * GoldenConstant;
+}
+
 template<size_t Size, typename T>
 constexpr auto lemireModuloReductionAlternative(T input) noexcept {
     static_assert(sizeof(T) == sizeof(uint64_t));
@@ -166,7 +180,6 @@ template<typename Key>auto reducedhashUnitary(Key k) noexcept {
 template<typename Key>auto slotFromKeyUnitary(Key k) noexcept {
     return 1;
 }
-
 
 } // namespace rh
 } // namespace zoo

--- a/inc/zoo/map/RobinHood_straw.h
+++ b/inc/zoo/map/RobinHood_straw.h
@@ -28,7 +28,6 @@ struct StrawMetadata {
 };
 
 template<u8 PSLBits, u8 HashBits, typename Key> struct StrawmanMap {
-  
   template <typename KeyCheck>
   bool exists(Key k, KeyCheck kc) {
     return findSlot(k, kc).second;

--- a/inc/zoo/swar/SWAR.h
+++ b/inc/zoo/swar/SWAR.h
@@ -45,6 +45,9 @@ template<int NBits_, typename T = uint64_t>
 struct SWAR {
     constexpr static inline auto NBits = NBits_;
     static constexpr inline auto Lanes = sizeof(T) * 8 / NBits;
+    constexpr static T BitMod = sizeof(T)*8 % NBits;
+    constexpr static T ValidBitsCount = sizeof(T)*8 - BitMod;
+    constexpr static T AllOnes = (BitMod == 0) ? ~(T(0)) : ((T(1) << ValidBitsCount) -1);
 
     SWAR() = default;
     constexpr explicit SWAR(T v): m_v(v) {}
@@ -237,7 +240,6 @@ template<int NBits, uint64_t T>
 constexpr auto leastNBitsMask() {
     return ~((0ull)<<NBits);
 }
-
 
 template<int NBits, typename T = uint64_t>
 constexpr T mostNBitsMask() {

--- a/test/map/RobinHood.test.cpp
+++ b/test/map/RobinHood.test.cpp
@@ -1,7 +1,12 @@
 #include "zoo/map/RobinHood.h"
+#include "zoo/map/RobinHoodAlt.h"
 #include "zoo/map/RobinHoodUtil.h"
 
 #include <catch2/catch.hpp>
+
+using namespace zoo;
+using namespace zoo::swar;
+using namespace zoo::rh;
 
 using u64 = uint64_t;
 using u32 = uint32_t;
@@ -109,4 +114,30 @@ TEST_CASE(
     CHECK(0x0000'ffff'ffff'ffffull == zoo::rh::badMixer<48>(v));
     CHECK(0x0000'0000'ffff'ffffull == zoo::rh::badMixer<32>(v));
     CHECK(0x0000'0000'0000'ffffull == zoo::rh::badMixer<16>(v));
+}
+
+TEST_CASE(
+    "SlotMetadataBasic",
+    "[robinhood]"
+) {
+    using SM = SWAR<8, u32>;
+    using SO35u32Ops = SlotOperations<3,5,u32>;
+    using MD35u32Ops = SlotMetadata<3,5,u32>;
+    CHECK(0x0504'0302u == SO35u32Ops::needlePSL(1).value());
+
+    // 0 psl is reserved.
+    const auto psl1 = 0x0403'0201u;
+    const auto hash1 = 0x8080'8080u;
+    {
+    MD35u32Ops m;
+    m.data_ = MD35u32Ops::SSL{0x0403'8201};
+    CHECK(0x0000'8000u == m.attemptMatch(SM{hash1}, SM{psl1}).value());
+    CHECK(0x0000'8000u == SO35u32Ops::attemptMatch(m.data_, SM{hash1}, SM{psl1}).value());
+    }
+    {
+    MD35u32Ops m;
+    m.data_ = MD35u32Ops::SSL{0x0401'8201};
+    CHECK(0x0000'8001u == m.attemptMatch(SM{hash1}, SM{psl1}).value());
+    CHECK(0x0000'8001u == SO35u32Ops::attemptMatch(m.data_, SM{hash1}, SM{psl1}).value());
+    } 
 }


### PR DESCRIPTION
alt rh constructs.

Adds SlotSplitKeys as a metadata collection and RH as a swar rh table. Implements basic find.
attempts to set up useful abstraction blocks around subpieces of RH table.
basic tests around matching.