### PR TITLE
SWAR insertion

### DIFF
--- a/design/RobinHood-SWAR.md
+++ b/design/RobinHood-SWAR.md
@@ -1,0 +1,20 @@
+# Design notes concerning Robin Hood implemented with SWAR techniques.
+
+## TL;DR
+
+Here are some annotations about design, implementation choices that are better
+described in natural text than alongside the source code.
+This is not complete.
+
+## Some notes
+
+The types in the "core" routines use return types with multiple values but they
+don't introduce performance problems, on the contrary, these calculated values
+are made available if needed afterward and prevent recomputation or allow a
+simpler programming style.
+
+I (Eddie) have seen in the generated assembler that the return values of type
+struct of multiple fields do not trigger a performance penalty, the reason is
+that all of the important routines are inlined, the compiler merges all of the
+C++ sources to be inlined and thus trivially eliminate the things that are not
+needed in a particular path.

--- a/inc/zoo/map/RobinHood.h
+++ b/inc/zoo/map/RobinHood.h
@@ -19,68 +19,6 @@
 
 namespace zoo {
 
-template<typename T>
-struct GeneratorFromPointer {
-    T *p_;
-
-    constexpr T &operator*() noexcept { return *p_; }
-    constexpr GeneratorFromPointer operator++() noexcept { return {++p_}; }
-};
-
-template<typename T, int MisalignmentBits>
-struct MisalignedGenerator {
-    T *base_;
-    constexpr static auto Width = sizeof(T) * 8;
-
-    constexpr T operator*() noexcept {
-        auto firstPart = base_[0];
-        auto secondPart = base_[1];
-            // how to make sure the "logical" shift right is used, regardless
-            // of the signedness of T?
-            // I'd prefer to not use std::make_unsigned_t, since how do we
-            // "make unsigned" user types?
-        auto firstPartLowered = firstPart.value() >> MisalignmentBits;
-        auto secondPartRaised =
-            secondPart.value() << (Width - MisalignmentBits);
-        return T{firstPartLowered | secondPartRaised};
-    }
-
-    constexpr MisalignedGenerator operator++() noexcept { return {++base_}; }
-};
-
-template<typename T>
-struct MisalignedGenerator<T, 0>: GeneratorFromPointer<T> {};
-
-template<typename T>
-struct MisalignedGenerator_Dynamic {
-    constexpr static auto Width = sizeof(T) * 8;
-    T *base_;
-
-    int misalignmentFirst, misalignmentSecond;
-
-    MisalignedGenerator_Dynamic(T *base, int ma):
-        base_(base),
-        misalignmentFirst(ma), misalignmentSecond(Width - ma)
-    {}
-    
-
-    constexpr T operator*() noexcept {
-        auto firstPart = base_[0];
-        auto secondPart = base_[1];
-            // how to make sure the "logical" shift right is used, regardless
-            // of the signedness of T?
-            // I'd prefer to not use std::make_unsigned_t, since how do we
-            // "make unsigned" user types?
-        auto firstPartLowered = firstPart.value() >> misalignmentFirst;
-        auto secondPartRaised = secondPart.value() << misalignmentSecond;
-        return T{firstPartLowered | secondPartRaised};
-    }
-
-    constexpr MisalignedGenerator_Dynamic operator++() noexcept {
-        ++base_; return *this;
-    }
-};
-
 namespace rh {
 
 template<int PSL_Bits, int HashBits, typename U = std::uint64_t>
@@ -280,41 +218,6 @@ struct RH_Backend {
     }
 
 };
-
-template<int NBits, typename U>
-constexpr auto hashReducer(U n) noexcept {
-    constexpr auto Shift = (NBits * ((sizeof(U)*8 / NBits) - 1));
-    constexpr auto AllOnes = meta::BitmaskMaker<U, 1, NBits>::value;
-    auto temporary = AllOnes * n;
-    auto higestNBits = temporary >> Shift;
-    return
-        (0 == (64 % NBits)) ?
-            higestNBits :
-            swar::isolate<NBits>(higestNBits);
-}
-
-
-template<typename T>
-constexpr auto fibonacciIndexModulo(T index) {
-    constexpr std::array<uint64_t, 4>
-        GoldenRatioReciprocals = {
-            159,
-            40503,
-            2654435769,
-            11400714819323198485ull,
-        };
-    constexpr T MagicalConstant =
-        T(GoldenRatioReciprocals[meta::logFloor(sizeof(T)) - 3]);
-    return index * MagicalConstant;
-}
-
-template<size_t Size, typename T>
-constexpr auto lemireModuloReductionAlternative(T input) noexcept {
-    static_assert(sizeof(T) == sizeof(uint64_t));
-    static_assert(Size < (1ull << 32));
-    auto halved = uint32_t(input);
-    return Size * input >> 32;
-}
 
 template<typename K, typename MV>
 struct KeyValuePairWrapper {

--- a/inc/zoo/map/RobinHood.h
+++ b/inc/zoo/map/RobinHood.h
@@ -1,9 +1,8 @@
 #ifndef ZOO_ROBINHOOD_H
 #define ZOO_ROBINHOOD_H
 
-#include "zoo/swar/SWAR.h"
-#include "zoo/AlignedStorage.h"
 #include "zoo/map/RobinHoodUtil.h"
+#include "zoo/AlignedStorage.h"
 
 #ifndef ZOO_CONFIG_DEEP_ASSERTIONS
     #define ZOO_CONFIG_DEEP_ASSERTIONS 0

--- a/inc/zoo/map/RobinHood.h
+++ b/inc/zoo/map/RobinHood.h
@@ -279,13 +279,6 @@ struct RH_Backend {
         }
     }
 
-    template<typename Inserter>
-    constexpr auto
-    evictionChain(Inserter, int index) {
-        auto baseIndex = index / Metadata::Lanes;
-        constexpr auto Ones = meta::BitmaskMaker<U, 1, Width>::value;
-        constexpr auto Progression = Metadata{Ones * Ones};
-    }
 };
 
 template<int NBits, typename U>

--- a/inc/zoo/map/RobinHood.h
+++ b/inc/zoo/map/RobinHood.h
@@ -471,12 +471,15 @@ struct RH_Frontend_WithSkarupkeTail {
         constexpr auto MaxRelocations = 64;
         std::array<std::size_t, MaxRelocations> relocations;
         auto relocationsCount = 0;
-        auto needlePSLs = needle.PSLs();
+        //auto needlePSLs = needle.PSLs();
         for(;;) {
             // Loop invariant:
             // deadline is true, swarIndex (but not `index`), intraIndex is set
             // mdp points to the haystack that gave the deadline
             // needle is correct
+            
+            // Make a backup for making the new needle since we will change
+            // this in the eviction
             auto mdBackup = *mdp;
             auto evictedPSL = mdBackup.PSLs().at(intraIndex);
             if(0 == evictedPSL) { // end of eviction chain!
@@ -532,7 +535,7 @@ struct RH_Frontend_WithSkarupkeTail {
             auto evictedPSLWithProgressionFromZero =
                 broadcastedEvictedPSL + ProgressionFromZero;
                 // | ePSL+0 | ePSL+1 | ePSL+2 | ePSL+3 | ... | ePSL+7 |
-            needlePSLs =
+            auto needlePSLs =
                 evictedPSLWithProgressionFromZero.shiftLanesLeft(intraIndex);
                     // zeroes make the new needle
                     // "richer" in all elements lower than the deadline

--- a/inc/zoo/map/RobinHoodUtil.h
+++ b/inc/zoo/map/RobinHoodUtil.h
@@ -3,8 +3,7 @@
 #include "zoo/swar/SWAR.h"
 
 #include <array>
-#include <cassert>
-#include <vector>
+#include <cstddef>
 
 namespace zoo {
 

--- a/inc/zoo/swar/SWAR.h
+++ b/inc/zoo/swar/SWAR.h
@@ -92,6 +92,14 @@ struct SWAR {
         return SWAR((m_v & ~elementMask) | (value << (index * NBits)));
     }
 
+    constexpr SWAR shiftLanesLeft(int laneCount) const noexcept {
+        return SWAR(value() << (NBits * laneCount));
+    }
+
+    constexpr SWAR shiftLanesRight(int laneCount) const noexcept {
+        return SWAR(value() >> (NBits * laneCount));
+    }
+
     T m_v;
 };
 

--- a/inc/zoo/swar/SWAR.h
+++ b/inc/zoo/swar/SWAR.h
@@ -83,8 +83,13 @@ struct SWAR {
     constexpr int top() const noexcept { return msbIndex(m_v) / NBits; }
     constexpr int lsbIndex() const noexcept { return __builtin_ctzll(m_v) / NBits; }
 
-    constexpr SWAR set(int index, int bit) const noexcept {
+    constexpr SWAR setBit(int index, int bit) const noexcept {
         return SWAR(m_v | (T(1) << (index * NBits + bit)));
+    }
+
+    constexpr auto blitElement(int index, T value) const noexcept {
+        auto elementMask = ((T(1) << NBits) - 1) << (index * NBits);
+        return SWAR((m_v & ~elementMask) | (value << (index * NBits)));
     }
 
     T m_v;

--- a/test/map/RobinHood.test.cpp
+++ b/test/map/RobinHood.test.cpp
@@ -33,6 +33,10 @@ auto instantiateFind(int v, FrontendExample &f) {
     return f.find(v);
 }
 
+auto instantiateInsert(int v, FrontendExample &f) {
+    return f.insert(v, 0);
+}
+
 
 static_assert(
     0xE9E8E7E6E5E4E3E2ull == RHC::makeNeedle(1, 7).value()

--- a/test/swar/BasicOperations.cpp
+++ b/test/swar/BasicOperations.cpp
@@ -247,3 +247,4 @@ static_assert(0x00E0'0000 == Lanes(allF).most(2));
 static_assert(0xE000'0000 == Lanes(allF).most(3));
 
 static_assert(0x123 == SWAR<4, uint32_t>(0x173).blitElement(1, 2).value());
+static_assert(0 == isolateLSB(u32(0)));

--- a/test/swar/BasicOperations.cpp
+++ b/test/swar/BasicOperations.cpp
@@ -246,3 +246,4 @@ static_assert(0x0000'E000 == Lanes(allF).most(1));
 static_assert(0x00E0'0000 == Lanes(allF).most(2));
 static_assert(0xE000'0000 == Lanes(allF).most(3));
 
+static_assert(0x123 == SWAR<4, uint32_t>(0x173).blitElement(1, 2).value());


### PR DESCRIPTION
First cut of insertion into Robin Hood table via swar methods.
First figures out the chain of insertions that need to happen (to some fixed maximum), then applies those insertions.
Fairly involved.