### PR TITLE
Insertion improvements (tests)

### DIFF
--- a/inc/zoo/map/RobinHood.h
+++ b/inc/zoo/map/RobinHood.h
@@ -16,7 +16,6 @@
     #include <assert>
 #endif
 
-template<typename> struct GT;
 
 namespace zoo {
 

--- a/inc/zoo/map/RobinHood.h
+++ b/inc/zoo/map/RobinHood.h
@@ -16,6 +16,8 @@
     #include <assert>
 #endif
 
+template<typename> struct GT;
+
 namespace zoo {
 
 namespace rh {
@@ -62,14 +64,14 @@ struct RH_Backend {
             // significant bits is to be able to call the cheaper version
             // _MSB_off here
 
-        auto theyBreakInvaraint = not theyKeepInvariant;
+        auto theyBreakInvariant = not theyKeepInvariant;
         // because we make the assumption of LITTLE ENDIAN byte ordering,
         // we're interested in the elements up to the first haystack-richer
-        auto firstBreakage = swar::isolateLSB(theyBreakInvaraint.value());
+        auto firstBreakage = swar::isolateLSB(theyBreakInvariant.value());
         return firstBreakage;
     }
 
-    constexpr static impl::MatchResult<PSL_Bits, HashBits>
+    constexpr static impl::MatchResult<PSL_Bits, HashBits, U>
     potentialMatches(
         Metadata needle, Metadata haystack
     ) noexcept {
@@ -79,11 +81,11 @@ struct RH_Backend {
         // to analyze before the deadline, "maskify" it.  Remember, the
         // deadline element itself can't be a potential match, it does
         // not need preservation.
-        auto deadlineMaskified = Metadata{deadline - 1};
-        auto beforeDeadlineMatches = sames & deadlineMaskified;
+        auto deadlineMaskified = deadline - 1;
+        auto beforeDeadlineMatches = sames.value() & deadlineMaskified;
         return {
             deadline,
-            beforeDeadlineMatches
+            Metadata{beforeDeadlineMatches}
         };
     }
 

--- a/inc/zoo/map/RobinHood.h
+++ b/inc/zoo/map/RobinHood.h
@@ -244,32 +244,6 @@ struct KeyValuePairWrapper {
     const auto &value() const noexcept { return const_cast<KeyValuePairWrapper *>(this)->value(); }
 };
 
-template<typename K, typename MV>
-struct KeyValuePairWrapper {
-    using type = std::pair<K, MV>;
-    AlignedStorageFor<type> pair_;
-
-    template<typename... Initializers>
-    void build(Initializers &&...izers)
-        noexcept(noexcept(pair_.template build<type>(std::forward<Initializers>(izers)...)))
-    {
-        pair_.template build<type>(std::forward<Initializers>(izers)...);
-    }
-
-    template<typename RHS>
-    KeyValuePairWrapper &operator=(RHS &&rhs)
-        noexcept(noexcept(std::declval<type &>() = std::forward<RHS>(rhs)))
-    {
-        *pair_.template as<type>() = std::forward<RHS>(rhs);
-        return *this;
-    }
-
-    void destroy() noexcept { pair_.template destroy<type>(); }
-
-    auto &value() noexcept { return *this->pair_.template as<type>(); }
-    const auto &value() const noexcept { return const_cast<KeyValuePairWrapper *>(this)->value(); }
-};
-
 template<
     typename K,
     typename MV,

--- a/inc/zoo/map/RobinHood.h
+++ b/inc/zoo/map/RobinHood.h
@@ -77,14 +77,15 @@ struct RH_Backend {
         // We need to determine if there are potential matches to consider
         auto sames = equals(needle, haystack);
         auto deadline = firstInvariantBreakage(needle, haystack);
-        // to analyze before the deadline, "maskify" it.  Remember, the
-        // deadline element itself can't be a potential match, it does
-        // not need preservation.
-        auto deadlineMaskified = deadline - 1;
-        auto beforeDeadlineMatches = sames.value() & deadlineMaskified;
+        // In a valid haystack, the PSLs can grow at most by 1 per entry.
+        // If a PSL is richer than the needle in any place, because the
+        // needle, by construction, always grows at least by 1 per entry,
+        // then the PSL won't be equal again.
+        // There is no need to filter potential matches using the deadline
+        // as previous versions of the code did.
         return {
             deadline,
-            Metadata{beforeDeadlineMatches}
+            sames
         };
     }
 

--- a/inc/zoo/map/RobinHoodUtil.h
+++ b/inc/zoo/map/RobinHoodUtil.h
@@ -79,16 +79,16 @@ using u8 = uint8_t;
 namespace impl {
 
 /// \todo decide on whether to rename this?
-template<int PSL_Bits, int HashBits, typename U = std::uint64_t>
-struct Metadata: swar::SWARWithSubLanes<HashBits, PSL_Bits, U> {
-    using Base = swar::SWARWithSubLanes<HashBits, PSL_Bits, U>;
+template<int PSL_Bits, int HashBits, typename U>
+struct Metadata: swar::SWARWithSubLanes<PSL_Bits, HashBits, U> {
+    using Base = swar::SWARWithSubLanes<PSL_Bits, HashBits, U>;
     using Base::Base;
 
     constexpr auto PSLs() const noexcept { return this->least(); }
     constexpr auto Hashes() const noexcept { return this->most(); }
 };
 
-template<int PSL_Bits, int HashBits, typename U = std::uint64_t>
+template<int PSL_Bits, int HashBits, typename U>
 struct MatchResult {
     U deadline;
     Metadata<PSL_Bits, HashBits, U> potentialMatches;

--- a/inc/zoo/swar/SWAR.h
+++ b/inc/zoo/swar/SWAR.h
@@ -117,18 +117,18 @@ struct SWAR {
 // versa.  In the spirit of separation of concerns, we provide a cut-lane-SWAR
 // abstraction here.
 
-template<int NBitsMost, int NBitsLeast, typename T = uint64_t>
-struct SWARWithSubLanes: SWAR<NBitsMost+NBitsLeast, T> {
+template<int NBitsLeast, int NBitsMost, typename T = uint64_t>
+struct SWARWithSubLanes: SWAR<NBitsMost + NBitsLeast, T> {
     using Base = SWAR<NBitsMost + NBitsLeast, T>;
     static constexpr inline auto Available = sizeof(T);
-    static constexpr inline auto LaneBits = NBitsLeast+NBitsMost;
+    static constexpr inline auto LaneBits = NBitsLeast + NBitsMost;
     static constexpr inline auto NSlots = Available * 8 / LaneBits;
 
     using Base::Base;
+    constexpr SWARWithSubLanes(Base b) noexcept: Base(b) {}
     constexpr SWARWithSubLanes(T most, T least) noexcept:
         Base((most << NBitsLeast) | least)
     {}
-    constexpr SWARWithSubLanes(Base b) noexcept: Base(b) {}
 
     // M is most significant bits slice, L is least significant bits slice.
     // 0x....M2L2M1L1 or MN|LN||...||M2|L2||M1|L1

--- a/test/map/RobinHood.test.cpp
+++ b/test/map/RobinHood.test.cpp
@@ -88,8 +88,6 @@ TEST_CASE("RobinHood potentialMatches", "[api][mapping][swar][robin-hood]") {
     auto missHaystack = RH35u32::Metadata{0x0707'0707u};
     auto m2 = RH35u32::potentialMatches(needle, missHaystack);
     CHECK(0x0000'0000u == m2.potentialMatches.value());
-    // We get a deadline here, incorrect.
-    //CHECK(0x0000'0080u == m2.deadline);
     CHECK(0 == m2.deadline);
 
     // If the haystack has no matches and has a richer element, we should get a
@@ -97,9 +95,6 @@ TEST_CASE("RobinHood potentialMatches", "[api][mapping][swar][robin-hood]") {
     auto deadlineHaystack = RH35u32::Metadata{0x0515'0403u};
     auto m3 = RH35u32::potentialMatches(needle, deadlineHaystack);
     CHECK(0x0080'0000u == m3.potentialMatches.value());
-    // Position 4 has needle psl 6 vs haystack psl 5, which should result in a
-    // deadline.
-    //CHECK(0x0000'0000u == m3.deadline);
     CHECK(0x80'00'00'00 == m3.deadline);
 }
 

--- a/test/map/RobinHood.test.cpp
+++ b/test/map/RobinHood.test.cpp
@@ -57,7 +57,7 @@ TEST_CASE("Robin Hood", "[api][mapping][swar][robin-hood]") {
 }
 
 
-using RH35u32 = zoo::rh::RH_Backend<3,5,u32>;
+using RH35u32 = zoo::rh::RH_Backend<3, 5, u32>;
 //makeNeedle
 //template<int PSL_Bits, int HashBits, typename U = std::uint64_t>
 
@@ -81,7 +81,6 @@ TEST_CASE("RobinHood potentialMatches", "[api][mapping][swar][robin-hood]") {
     auto m1 = RH35u32::potentialMatches(needle, haystack);
     CHECK(0x0000'0000u == m1.deadline);
 
-    #if 0
     CHECK(0x8080'8080u == m1.potentialMatches.value());
 
     // If haystack has no matches and is poorer than needle, we should get no
@@ -90,17 +89,18 @@ TEST_CASE("RobinHood potentialMatches", "[api][mapping][swar][robin-hood]") {
     auto m2 = RH35u32::potentialMatches(needle, missHaystack);
     CHECK(0x0000'0000u == m2.potentialMatches.value());
     // We get a deadline here, incorrect.
-    CHECK(0x0000'0080u == m2.deadline);
+    //CHECK(0x0000'0080u == m2.deadline);
+    CHECK(0 == m2.deadline);
 
-    // If haystack has no matches and has a richer element, we should get a
+    // If the haystack has no matches and has a richer element, we should get a
     // deadline and no matches.
     auto deadlineHaystack = RH35u32::Metadata{0x0515'0403u};
     auto m3 = RH35u32::potentialMatches(needle, deadlineHaystack);
     CHECK(0x0080'0000u == m3.potentialMatches.value());
     // Position 4 has needle psl 6 vs haystack psl 5, which should result in a
     // deadline.
-    CHECK(0x0000'0000u == m3.deadline);
-    #endif
+    //CHECK(0x0000'0000u == m3.deadline);
+    CHECK(0x80'00'00'00 == m3.deadline);
 }
 
 

--- a/test/map/RobinHood.test.cpp
+++ b/test/map/RobinHood.test.cpp
@@ -35,6 +35,7 @@ auto instantiateFED(FrontendExample *ptr) {
     delete ptr;
 }
 
+/*
 auto instantiateFind(int v, FrontendExample &f) {
     return f.find(v);
 }
@@ -42,7 +43,7 @@ auto instantiateFind(int v, FrontendExample &f) {
 auto instantiateInsert(int v, FrontendExample &f) {
     return f.insert(v, 0);
 }
-
+*/
 
 static_assert(
     0xE9E8E7E6E5E4E3E2ull == RHC::makeNeedle(1, 7).value()
@@ -75,10 +76,12 @@ TEST_CASE("RobinHood potentialMatches", "[api][mapping][swar][robin-hood]") {
 
     // If haystack is identical to needle, we get no deadline and 4 potential
     // matches.
-    auto haystack = RH35u32::Metadata{0x1615'1413u};
+    auto haystack = RH35u32::Metadata{0x1615'1413};
     CHECK(haystack.value() == needle.value());
     auto m1 = RH35u32::potentialMatches(needle, haystack);
     CHECK(0x0000'0000u == m1.deadline);
+
+    #if 0
     CHECK(0x8080'8080u == m1.potentialMatches.value());
 
     // If haystack has no matches and is poorer than needle, we should get no
@@ -97,7 +100,9 @@ TEST_CASE("RobinHood potentialMatches", "[api][mapping][swar][robin-hood]") {
     // Position 4 has needle psl 6 vs haystack psl 5, which should result in a
     // deadline.
     CHECK(0x0000'0000u == m3.deadline);
+    #endif
 }
+
 
 TEST_CASE(
     "BadMix",

--- a/test/swar/BasicOperations.cpp
+++ b/test/swar/BasicOperations.cpp
@@ -206,7 +206,7 @@ GE_MSB_TEST(0x7777'7777,
             0x8888'8888)
 
 // 3 bits on msb side, 5 bits on lsb side.
-using Lanes = SWARWithSubLanes<3,5,u32>;
+using Lanes = SWARWithSubLanes<5, 3, u32>;
 using S8u32 = SWAR<8, u32>;
 static constexpr inline u32 allF = broadcast<8>(S8u32(0x0000'00FFul)).value();
 

--- a/test/swar/BasicOperations.cpp
+++ b/test/swar/BasicOperations.cpp
@@ -25,17 +25,17 @@ TEST_CASE(
     "Isolate",
     "[swar]"
 ) {
-    for (auto i = 0; i < 63; ++i) { 
+    for (auto i = 0; i < 63; ++i) {
       CHECK(i == isolate<8>(i));
       CHECK(i == isolate<8>(0xFF00+i));
       CHECK(i == isolate<8>(0xFFFF00+i));
     }
-    for (auto i = 0; i < 31; ++i) { 
+    for (auto i = 0; i < 31; ++i) {
       CHECK(i == isolate<7>(i));
       CHECK(i == isolate<7>(0xFF00+i));
       CHECK(i == isolate<7>(0xFFFF00+i));
     }
-    for (auto i = 0; i < 31; ++i) { 
+    for (auto i = 0; i < 31; ++i) {
       CHECK(i == isolate<11>(i));
       CHECK(i == isolate<11>(0xF800+i));
       CHECK(i == isolate<11>(0xFFF800+i));


### PR DESCRIPTION
Material reduction in instructions in inner find loop by removing the check against deadlines: the PSL growth patterns mean that any deadline breach will result in no full match from calling equals(haystack, needle).
Fixes a few basic tests related to matching.
Switches SWARWithSublanes to <least, most> standard on specifying bit positions.
