### PR TITLE
Finish the conversion of SWARWithSubLanes from <Most,Least> to <Least,Most>

### DIFF
--- a/inc/zoo/swar/SWAR.h
+++ b/inc/zoo/swar/SWAR.h
@@ -139,7 +139,7 @@ struct SWARWithSubLanes: SWAR<NBitsMost_ + NBitsLeast_, T> {
 
     // M is most significant bits slice, L is least significant bits slice.
     // 0x....M2L2M1L1 or MN|LN||...||M2|L2||M1|L1
-    using SL = SWARWithSubLanes<NBitsMost, NBitsLeast, T>;
+    using SL = SWARWithSubLanes<NBitsLeast, NBitsMost, T>;
 
     //constexpr T Ones = meta::BitmaskMaker<NBits, SWAR<NBits, T>{1}.value(), T>::value;
     static constexpr inline auto LeastOnes = meta::BitmaskMaker<T, Base{1}.value(), LaneBits>::value;

--- a/test/swar/BasicOperations.cpp
+++ b/test/swar/BasicOperations.cpp
@@ -208,6 +208,7 @@ GE_MSB_TEST(0x7777'7777,
 // 3 bits on msb side, 5 bits on lsb side.
 using Lanes = SWARWithSubLanes<5, 3, u32>;
 using S8u32 = SWAR<8, u32>;
+static constexpr inline u32 all0 = 0;
 static constexpr inline u32 allF = broadcast<8>(S8u32(0x0000'00FFul)).value();
 
 static_assert(allF == Lanes(allF).value());
@@ -232,6 +233,16 @@ static_assert(0xFF1F'FFFF == Lanes(allF).most(0,2).value());
 static_assert(0xFF3F'FFFF == Lanes(allF).most(1,2).value());
 static_assert(0x1FFF'FFFF == Lanes(allF).most(0,3).value());
 static_assert(0x3FFF'FFFF == Lanes(allF).most(1,3).value());
+
+static_assert(0x0000'001f == Lanes(all0).least(31, 0).most(0, 0).value());
+static_assert(0x0000'1f00 == Lanes(all0).least(31, 1).most(0, 1).value());
+static_assert(0x001f'0000 == Lanes(all0).least(31, 2).most(0, 2).value());
+static_assert(0x1f00'0000 == Lanes(all0).least(31, 3).most(0, 3).value());
+
+static_assert(0x0000'00e0 == Lanes(all0).least(0, 0).most(31, 0).value());
+static_assert(0x0000'e000 == Lanes(all0).least(0, 1).most(31, 1).value());
+static_assert(0x00e0'0000 == Lanes(all0).least(0, 2).most(31, 2).value());
+static_assert(0xe000'0000 == Lanes(all0).least(0, 3).most(31, 3).value());
 
 static_assert(0x1F1F'1F1F == Lanes(allF).least().value());
 static_assert(0xE0E0'E0E0 == Lanes(allF).most());


### PR DESCRIPTION
The conversion of SWARWIthSubLanes from most,least to least,most was incomplete, and the tests didn't cover it b/c it only manifested when the returned auto type (which had most, least flipped) was then used again directly.