### PR TITLE
[robin hood][swar] Testing for robin hood find. Expose dependence on undefined shift behavior, fix.

### DIFF
--- a/inc/zoo/map/RobinHood.h
+++ b/inc/zoo/map/RobinHood.h
@@ -163,10 +163,10 @@ struct RH_Backend {
         __builtin_unreachable();
     }
 
-    // Returned metadata is all garbage except for any entry in a deadline,
-    // which contains the PSL and hash of the element which matches the
-    // deadline. IE: it is returnedMetadata.at(deadline.lsbindex()) that is the
-    // PSL+hashbits
+    // Returned metadata is irrelevant except for the element at the same index
+    // as the deadline which contains the PSL and hash of the element which
+    // matches the deadline. IE: it is returnedMetadata.at(deadline.lsbindex())
+    // that is the PSL + hashbits
     template<typename KeyComparer>
     constexpr auto
     findMisaligned_assumesSkarupkeTail(
@@ -218,7 +218,7 @@ struct RH_Backend {
                 auto toAbsolute = [](auto v, auto ma) {
                     auto shiftedLeft = v.shiftLanesLeft(ma);
                     auto shiftedRight =
-                        v.shiftLanesRightSafe(Metadata::NSlots - ma).shiftOneBitRight();
+                        v.shiftLanesRight(Metadata::NSlots - ma - 1).shiftLanesRight(1);
                     return Metadata{shiftedLeft | shiftedRight};
                 };
                 auto position = index + Metadata{deadline}.lsbIndex();

--- a/inc/zoo/map/RobinHoodUtil.h
+++ b/inc/zoo/map/RobinHoodUtil.h
@@ -43,11 +43,11 @@ struct MisalignedGenerator_Dynamic {
     constexpr static auto Width = sizeof(T) * 8;
     T *base_;
 
-    int misalignmentFirst, misalignmentSecond;
+    int misalignmentFirst, misalignmentSecondLessOne;
 
     MisalignedGenerator_Dynamic(T *base, int ma):
         base_(base),
-        misalignmentFirst(ma), misalignmentSecond(Width - ma)
+        misalignmentFirst(ma), misalignmentSecondLessOne(Width - ma - 1)
     {}
     
 
@@ -59,7 +59,8 @@ struct MisalignedGenerator_Dynamic {
             // I'd prefer to not use std::make_unsigned_t, since how do we
             // "make unsigned" user types?
         auto firstPartLowered = firstPart.value() >> misalignmentFirst;
-        auto secondPartRaised = secondPart.value() << misalignmentSecond;
+        // Avoid undefined behavior of << width of type.
+        auto secondPartRaised = (secondPart.value() << misalignmentSecondLessOne) << 1;
         return T{firstPartLowered | secondPartRaised};
     }
 
@@ -74,7 +75,6 @@ using u64 = uint64_t;
 using u32 = uint32_t;
 using u16 = uint16_t;
 using u8 = uint8_t;
-
 
 namespace impl {
 

--- a/inc/zoo/map/RobinHoodUtil.h
+++ b/inc/zoo/map/RobinHoodUtil.h
@@ -38,6 +38,8 @@ struct MisalignedGenerator {
 template<typename T>
 struct MisalignedGenerator<T, 0>: GeneratorFromPointer<T> {};
 
+// This is tightly coupled with a Metadata that happens-to have lane widths of
+// 8.
 template<typename T>
 struct MisalignedGenerator_Dynamic {
     constexpr static auto Width = sizeof(T) * 8;

--- a/inc/zoo/swar/SWAR.h
+++ b/inc/zoo/swar/SWAR.h
@@ -71,6 +71,13 @@ struct SWAR {
     SWAR_BINARY_OPERATORS_X_LIST
     #undef X
 
+    // Returns lane at position with other lanes cleared.
+    constexpr T lane(int position) const noexcept {
+        constexpr auto filter = (T(1) << NBits) - 1;
+        return m_v & (filter << (NBits * position));
+    }
+
+    // Returns lane value at position, in lane 0, rest of SWAR cleared.
     constexpr T at(int position) const noexcept {
         constexpr auto filter = (T(1) << NBits) - 1;
         return filter & (m_v >> (NBits * position));
@@ -103,6 +110,15 @@ struct SWAR {
 
     constexpr SWAR shiftLanesRight(int laneCount) const noexcept {
         return SWAR(value() >> (NBits * laneCount));
+    }
+
+    // This will shift 1 bit less right to avoid undefined behavior. Use only
+    // in conditions when the caller can prove that laneCount is not zero.
+    constexpr SWAR shiftLanesRightSafe(int laneCount) const noexcept {
+        return SWAR(value() >> ((NBits * laneCount) - 1));
+    }
+    constexpr SWAR shiftOneBitRight() const noexcept {
+        return SWAR(value() >> 1);
     }
 
     T m_v;

--- a/inc/zoo/swar/SWAR.h
+++ b/inc/zoo/swar/SWAR.h
@@ -72,7 +72,7 @@ struct SWAR {
     #undef X
 
     // Returns lane at position with other lanes cleared.
-    constexpr T lane(int position) const noexcept {
+    constexpr T isolateLane(int position) const noexcept {
         constexpr auto filter = (T(1) << NBits) - 1;
         return m_v & (filter << (NBits * position));
     }

--- a/inc/zoo/swar/SWAR.h
+++ b/inc/zoo/swar/SWAR.h
@@ -112,15 +112,6 @@ struct SWAR {
         return SWAR(value() >> (NBits * laneCount));
     }
 
-    // This will shift 1 bit less right to avoid undefined behavior. Use only
-    // in conditions when the caller can prove that laneCount is not zero.
-    constexpr SWAR shiftLanesRightSafe(int laneCount) const noexcept {
-        return SWAR(value() >> ((NBits * laneCount) - 1));
-    }
-    constexpr SWAR shiftOneBitRight() const noexcept {
-        return SWAR(value() >> 1);
-    }
-
     T m_v;
 };
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,5 +1,6 @@
 cmake_minimum_required (VERSION 3.8)
 
+set(CMAKE_BUILD_TYPE Debug)
 set(CMAKE_CXX_STANDARD 17)
 
 set(CMAKE_CXX_FLAGS_UBSAN "-fsanitize=undefined -fno-omit-frame-pointer -fno-optimize-sibling-calls -O1 -g")

--- a/test/map/RobinHood.test.cpp
+++ b/test/map/RobinHood.test.cpp
@@ -60,7 +60,7 @@ std::ostream &operator<<(std::ostream &out, V v) {
             if(v.intraIndex == ndx) {
                 ptr += sprintf(ptr, "<");
             }
-            ptr += sprintf(ptr, "%02llx", val & 0xFFull);
+            ptr += sprintf(ptr, "%02llx", val & 0xFF);
             if(v.intraIndex == ndx) {
                 ptr += sprintf(ptr, ">");
             }

--- a/test/map/RobinHood.test.cpp
+++ b/test/map/RobinHood.test.cpp
@@ -274,7 +274,7 @@ TEST_CASE("Robin Hood Metadata peek/poke u32 synthetic metadata block of three",
     // Returned metadata contains one valid lane: the lane at the offset of
     // deadline.
     CHECK(0x00c2'0000u ==
-        metadata.lane(FrontendSmall32::MD{deadline}.lsbIndex()));
+        metadata.isolateLane(FrontendSmall32::MD{deadline}.lsbIndex()));
     }
 }
 
@@ -334,7 +334,7 @@ TEST_CASE("Robin Hood Metadata peek/poke u32 synthetic metadata ",
     // Returned metadata contains one valid lane: the lane at the offset of
     // deadline.
     CHECK(0x00c2'0000u ==
-        metadata.lane(FrontendSmall32::MD{deadline}.lsbIndex()));
+        metadata.isolateLane(FrontendSmall32::MD{deadline}.lsbIndex()));
     }
 }
 

--- a/test/map/RobinHood.test.cpp
+++ b/test/map/RobinHood.test.cpp
@@ -23,16 +23,6 @@ using RHC = zoo::rh::RH_Backend<5, 3>;
 int *collectionOfKeys;
 RHC::Metadata *md;
 
-auto blue(int sPSL, int hh, int key, int homeIndex) {
-    RHC fromPointer{md};
-    auto r =
-        fromPointer.findMisaligned_assumesSkarupkeTail(
-            hh,
-            homeIndex,
-            [&](int matchIndex) { return collectionOfKeys[matchIndex] == key; }
-        );
-}
-
 using FrontendExample =
     zoo::rh::RH_Frontend_WithSkarupkeTail<int, int, 1024, 5, 3>;
 
@@ -70,7 +60,7 @@ std::ostream &operator<<(std::ostream &out, V v) {
             if(v.intraIndex == ndx) {
                 ptr += sprintf(ptr, "<");
             }
-            ptr += sprintf(ptr, "%02llx", val & 0xFF);
+            ptr += sprintf(ptr, "%02llx", val & 0xFFull);
             if(v.intraIndex == ndx) {
                 ptr += sprintf(ptr, ">");
             }
@@ -190,7 +180,6 @@ TEST_CASE("Robin Hood", "[api][mapping][swar][robin-hood]") {
     WARN(mirror.size());
 }
 
-#if 0
 using FrontendSmall32 =
     zoo::rh::RH_Frontend_WithSkarupkeTail<int, int, 16, 5, 3,
         std::hash<int>, std::equal_to<int>, u32>;
@@ -212,10 +201,11 @@ TEST_CASE("Robin Hood Metadata peek/poke u32",
     }
 }
 
-TEST_CASE("Robin Hood Metadata peek/poke u32 synthetic metadata",
+
+TEST_CASE("Robin Hood Metadata peek/poke u32 synthetic metadata basic",
           "[api][mapping][swar][robin-hood]") {
     FrontendSmall32 table;
-    /*
+
     zoo::rh::impl::poke(table.md_, 1, 0x1, 0x7);
     CHECK(std::tuple{1,0x7} == zoo::rh::impl::peek(table.md_, 1));
     CHECK(std::tuple{0,0} == zoo::rh::impl::peek(table.md_, 0));
@@ -228,23 +218,131 @@ TEST_CASE("Robin Hood Metadata peek/poke u32 synthetic metadata",
     CHECK(1 == index);
     CHECK(0x0000'0000u == deadline);
     CHECK(0x0000'0000u == metadata.value());
-    */
-    //U hoistedHash, int homeIndex, const KeyComparer &kc
-    //return std::tuple(position, deadline, Metadata(needle));
-
-
 }
-#endif
+
+template <typename MetadataCollection>
+void writeFourBlock(int offset, MetadataCollection& md) {
+    zoo::rh::impl::poke(md, 1+offset, 0x1, 0x7);
+    zoo::rh::impl::poke(md, 2+offset, 0x1, 0x5);
+    zoo::rh::impl::poke(md, 3+offset, 0x1, 0x3);
+    CHECK(std::tuple{0x1, 0x7} == zoo::rh::impl::peek(md, 1+offset));
+    CHECK(std::tuple{0x1, 0x5} == zoo::rh::impl::peek(md, 2+offset));
+    CHECK(std::tuple{0x1, 0x3} == zoo::rh::impl::peek(md, 3+offset));
+}
+
+TEST_CASE("Robin Hood Metadata peek/poke u32 synthetic metadata block of three",
+          "[api][mapping][swar][robin-hood]") {
+    FrontendSmall32 table;
+    writeFourBlock(0, table.md_);
+    CHECK(std::tuple{0,0} == zoo::rh::impl::peek(table.md_, 0));
+    CHECK(std::tuple{1,0x7} == zoo::rh::impl::peek(table.md_, 1));
+    CHECK(std::tuple{1,0x5} == zoo::rh::impl::peek(table.md_, 2));
+    CHECK(std::tuple{1,0x3} == zoo::rh::impl::peek(table.md_, 3));
+    CHECK(std::tuple{0,0} == zoo::rh::impl::peek(table.md_, 4));
+
+    FrontendSmall32::Backend be{table.md_.data()};
+    auto kcGen = [](int z) { return [z](int i){ return i == z;};};
+    auto trueKc = [](int z) { return true; };
+    {
+    auto [index, deadline, metadata] =
+        be.findMisaligned_assumesSkarupkeTail(0x7, 1, trueKc);
+    CHECK(1 == index);
+    CHECK(0x0000'0000u == deadline);
+    CHECK(0x0000'0000u == metadata.value());
+    }
+    {
+    auto [index, deadline, metadata] =
+        be.findMisaligned_assumesSkarupkeTail(0x5, 2, trueKc);
+    CHECK(2 == index);
+    CHECK(0x0000'0000u == deadline);
+    CHECK(0x0000'0000u == metadata.value());
+    }
+    {
+    auto [index, deadline, metadata] =
+        be.findMisaligned_assumesSkarupkeTail(0x3, 3, trueKc);
+    CHECK(3 == index);
+    CHECK(0x0000'0000u == deadline);
+    CHECK(0x0000'0000u == metadata.value());
+    }
+    {
+    auto [index, deadline, metadata] =
+        be.findMisaligned_assumesSkarupkeTail(0x6, 1, trueKc);
+    // try to find at homeIndex 1, receive idx 2 as insertionIndex, as idx 2
+    // has a psl of 1 and needle has psl of 2 at that point.
+    CHECK(2 == index);
+    CHECK(0x0080'0000u == deadline);
+    // Returned metadata contains one valid lane: the lane at the offset of
+    // deadline.
+    CHECK(0x00c2'0000u ==
+        metadata.lane(FrontendSmall32::MD{deadline}.lsbIndex()));
+    }
+}
+
+TEST_CASE("Robin Hood Metadata peek/poke u32 synthetic metadata ",
+          "[api][mapping][swar][robin-hood]") {
+    FrontendSmall32 table;
+    writeFourBlock(0, table.md_);
+    writeFourBlock(5, table.md_);
+    writeFourBlock(10, table.md_);
+    writeFourBlock(15, table.md_);
+    auto trueKc = [](int z) { return true; };
+
+    FrontendSmall32::Backend be{table.md_.data()};
+    for (auto i = 0 ; i< table.md_.size() ;i++) {
+      auto [p,h] =zoo::rh::impl::peek(table.md_, i);
+      if ( p == 0) continue;
+      // All lookups for entries in the metadata should work correctly.
+      auto [index, deadline, metadata] =
+          be.findMisaligned_assumesSkarupkeTail(h, i, trueKc);
+      CHECK(p == 1);
+      CHECK(i == index);
+      CHECK(0x0000'0000u == deadline);
+      CHECK(0x0000'0000u == metadata.value());
+
+    }
+
+
+    auto kcGen = [](int z) { return [z](int i){ return i == z;};};
+    {
+    auto [index, deadline, metadata] =
+        be.findMisaligned_assumesSkarupkeTail(0x7, 1, trueKc);
+    CHECK(1 == index);
+    CHECK(0x0000'0000u == deadline);
+    CHECK(0x0000'0000u == metadata.value());
+    }
+    {
+    auto [index, deadline, metadata] =
+        be.findMisaligned_assumesSkarupkeTail(0x5, 2, trueKc);
+    CHECK(2 == index);
+    CHECK(0x0000'0000u == deadline);
+    CHECK(0x0000'0000u == metadata.value());
+    }
+    {
+    auto [index, deadline, metadata] =
+        be.findMisaligned_assumesSkarupkeTail(0x3, 3, trueKc);
+    CHECK(3 == index);
+    CHECK(0x0000'0000u == deadline);
+    CHECK(0x0000'0000u == metadata.value());
+    }
+    {
+    auto [index, deadline, metadata] =
+        be.findMisaligned_assumesSkarupkeTail(0x6, 1, trueKc);
+    // try to find at homeIndex 1, receive idx 2 as insertionIndex, as idx 2
+    // has a psl of 1 and needle has psl of 2 at that point.
+    CHECK(2 == index);
+    CHECK(0x0080'0000u == deadline);
+    // Returned metadata contains one valid lane: the lane at the offset of
+    // deadline.
+    CHECK(0x00c2'0000u ==
+        metadata.lane(FrontendSmall32::MD{deadline}.lsbIndex()));
+    }
+}
 
 using RH35u32 = zoo::rh::RH_Backend<3, 5, u32>;
 
-TEST_CASE("RobinHood basic needle", "[api][mapping][swar][robin-hood]") {
-
-CHECK(0x0403'0201u == RH35u32::makeNeedle(0, 0).value());
-CHECK(0x1615'1413u == RH35u32::makeNeedle(2, 2).value());
-CHECK(0x1817'1615u == RH35u32::makeNeedle(4, 2).value());
-
-}
+static_assert(0x0403'0201u == RH35u32::makeNeedle(0, 0).value());
+static_assert(0x1615'1413u == RH35u32::makeNeedle(2, 2).value());
+static_assert(0x1817'1615u == RH35u32::makeNeedle(4, 2).value());
 
 TEST_CASE("RobinHood potentialMatches", "[api][mapping][swar][robin-hood]") {
     //U deadline, Metadata<PSL_Bits, HashBits, U> potentialMatches;


### PR DESCRIPTION
Undefined behavior of type << <typewidth> is indeed very bad. Avoid that by shifting n-1, then 1.  Fix usage in two places: misalignment generator and realignment of deadline/metadata post-find.

Add a few related functions.

Add some tests cases around finding vs artificially constructed (but valid) metadata.