### PR TITLE
[robin hood][swar] Make hash manipulation templatable in Robin Hood table.

### DIFF
--- a/inc/zoo/map/RobinHood.h
+++ b/inc/zoo/map/RobinHood.h
@@ -272,7 +272,10 @@ template<
     int PSL_Bits, int HashBits,
     typename Hash = std::hash<K>,
     typename KE = std::equal_to<K>,
-    typename U = std::uint64_t
+    typename U = std::uint64_t,
+    typename Scatter = FibonacciScatter<U>,
+    typename RangeReduce = LemireReduce<RequestedSize, U>,
+    typename HashReduce = TopHashReducer<HashBits, U>
 >
 struct RH_Frontend_WithSkarupkeTail {
     using Backend = RH_Backend<PSL_Bits, HashBits, U>;
@@ -328,13 +331,13 @@ struct RH_Frontend_WithSkarupkeTail {
 
     auto findParameters(const K &k) const noexcept {
         auto hashCode = Hash{}(k);
-        auto fibonacciScrambled = fibonacciIndexModulo(hashCode);
-        auto homeIndex =
-            lemireModuloReductionAlternative<RequestedSize>(fibonacciScrambled);
+
+        auto fibonacciScrambled = Scatter{}(hashCode);
+        auto homeIndex = RangeReduce{}(fibonacciScrambled);
         #if ZOO_CONFIG_DEEP_ASSERTIONS
             assert(homeIndex < RequestedSize);
         #endif
-        auto hoisted = hashReducer<HashBits>(hashCode);
+        auto hoisted = HashReduce{}(hashCode);
         return
             std::tuple{
                 hoisted,

--- a/inc/zoo/map/RobinHood.h
+++ b/inc/zoo/map/RobinHood.h
@@ -330,14 +330,10 @@ struct RH_Frontend_WithSkarupkeTail {
     }
 
     auto findParameters(const K &k) const noexcept {
-        auto hashCode = Hash{}(k);
-
-        auto fibonacciScrambled = Scatter{}(hashCode);
-        auto homeIndex = RangeReduce{}(fibonacciScrambled);
-        #if ZOO_CONFIG_DEEP_ASSERTIONS
-            assert(homeIndex < RequestedSize);
-        #endif
-        auto hoisted = HashReduce{}(hashCode);
+        auto [hoisted, homeIndex] =
+            findBasicParameters 
+                <K, RequestedSize, HashBits, U,
+                Hash, Scatter, RangeReduce, HashReduce >(k);
         return
             std::tuple{
                 hoisted,

--- a/test/map/BasicMap.cpp
+++ b/test/map/BasicMap.cpp
@@ -31,11 +31,11 @@ TEST_CASE(
 }
 
 TEST_CASE(
-    "StrawhoodBasic",
+    "Strawhood basic",
     "[robinhood]"
 ) {
     u32 sz = 9;
-    StrawmanMap<7, 9, u64> rhmap(sz);
+    StrawmanMap<7, 9, u64, 9> rhmap;
 
     CHECK(rhmap.keys_.size() == sz);
     CHECK(rhmap.md_.psls_.size() == sz);
@@ -54,5 +54,37 @@ TEST_CASE(
     CHECK(rhmap.exists(9, &keyCheck) == true);
     CHECK(rhmap.exists(11, &keyCheck) == true);
     CHECK(rhmap.insert(11, &keyCheck).first == 4);
+    CHECK(rhmap.exists(11, &keyCheck) == true);
+}
+
+TEST_CASE(
+    "Strawhood real hashes ",
+    "[robinhood]"
+) {
+    static constexpr auto sz = 9;
+    static constexpr auto hbits = 9;
+    StrawmanMap<7, hbits, u64, sz, std::hash<u64>,
+        FibonacciScatter<u64>,
+        LemireReduce<sz, u64>,
+        TopHashReducer<hbits, u64>
+    > rhmap;
+
+    CHECK(rhmap.keys_.size() == sz);
+    CHECK(rhmap.md_.psls_.size() == sz);
+    CHECK(rhmap.md_.hashes_.size() == sz);
+    CHECK(rhmap.insert(5, &keyCheck).second);
+    CHECK(rhmap.exists(5, &keyCheck) == true);
+    CHECK(!rhmap.insert(5, &keyCheck).second);
+    CHECK(rhmap.exists(5, &keyCheck) == true);
+    CHECK(rhmap.insert(7, &keyCheck).second);
+    CHECK(rhmap.exists(7, &keyCheck) == true);
+    CHECK(rhmap.insert(9, &keyCheck).second);
+    CHECK(rhmap.exists(9, &keyCheck) == true);
+    CHECK(rhmap.insert(11, &keyCheck).second);
+    CHECK(rhmap.exists(5, &keyCheck) == true);
+    CHECK(rhmap.exists(7, &keyCheck) == true);
+    CHECK(rhmap.exists(9, &keyCheck) == true);
+    CHECK(rhmap.exists(11, &keyCheck) == true);
+    CHECK(!rhmap.insert(11, &keyCheck).second);
     CHECK(rhmap.exists(11, &keyCheck) == true);
 }

--- a/test/map/RobinHood.test.cpp
+++ b/test/map/RobinHood.test.cpp
@@ -139,16 +139,16 @@ TEST_CASE("Robin Hood", "[api][mapping][swar][robin-hood]") {
 
     while(wordsEnd != wordIterator) {
         const auto &word = wordIterator->str();
-    //  WARN(word);
+        WARN(word);
         auto findResult = ex.find(word);
         auto mfr = mirror.find(word);
-    //  if("accomplishment" == word) {
-    //      WARN(mirror.size());
-    //  }
+        if("accomplishment" == word) {
+            WARN(mirror.size());
+        }
         bool resultEndInMirror = mfr == mirror.end();
         bool resultEndInExample = findResult == ex.end();
         if(resultEndInMirror != resultEndInExample) {
-    //      WARN(resultEndInMirror);
+            WARN(resultEndInMirror);
             auto r = ex.find(word);
         }
         REQUIRE(resultEndInMirror == resultEndInExample);
@@ -156,12 +156,12 @@ TEST_CASE("Robin Hood", "[api][mapping][swar][robin-hood]") {
             auto [hh, indexHome, dc] = ex.findParameters(word);
             auto index = (iter - ex.values_.begin());
             auto swarIndex = index / MD::NSlots;
-    //      WARN(
-    //          index << ':' << swarIndex << ':' <<
-    //          (index % MD::NSlots) << ' ' <<
-    //          showMetadata(index, ex.md_.data()) <<
-    //          ' ' << hh << ' ' << indexHome
-    //      );
+            WARN(
+                index << ':' << swarIndex << ':' <<
+                (index % MD::NSlots) << ' ' <<
+                showMetadata(index, ex.md_.data()) <<
+                ' ' << hh << ' ' << indexHome
+            );
         };
         if(resultEndInMirror) {
             mirror[word] = 1;
@@ -173,11 +173,11 @@ TEST_CASE("Robin Hood", "[api][mapping][swar][robin-hood]") {
             ++findResult->value().second;
             REQUIRE(mirror[word] == findResult->value().second);
             showRecord(findResult);
-    //      WARN(word << ' ' << mirror[word]);
+            WARN(word << ' ' << mirror[word]);
         }
         ++wordIterator;
     }
- // WARN(mirror.size());
+    WARN(mirror.size());
 }
 
 using FrontendSmall32 =

--- a/test/map/RobinHood.test.cpp
+++ b/test/map/RobinHood.test.cpp
@@ -139,16 +139,16 @@ TEST_CASE("Robin Hood", "[api][mapping][swar][robin-hood]") {
 
     while(wordsEnd != wordIterator) {
         const auto &word = wordIterator->str();
-        WARN(word);
+    //  WARN(word);
         auto findResult = ex.find(word);
         auto mfr = mirror.find(word);
-        if("accomplishment" == word) {
-            WARN(mirror.size());
-        }
+    //  if("accomplishment" == word) {
+    //      WARN(mirror.size());
+    //  }
         bool resultEndInMirror = mfr == mirror.end();
         bool resultEndInExample = findResult == ex.end();
         if(resultEndInMirror != resultEndInExample) {
-            WARN(resultEndInMirror);
+    //      WARN(resultEndInMirror);
             auto r = ex.find(word);
         }
         REQUIRE(resultEndInMirror == resultEndInExample);
@@ -156,12 +156,12 @@ TEST_CASE("Robin Hood", "[api][mapping][swar][robin-hood]") {
             auto [hh, indexHome, dc] = ex.findParameters(word);
             auto index = (iter - ex.values_.begin());
             auto swarIndex = index / MD::NSlots;
-            WARN(
-                index << ':' << swarIndex << ':' <<
-                (index % MD::NSlots) << ' ' <<
-                showMetadata(index, ex.md_.data()) <<
-                ' ' << hh << ' ' << indexHome
-            );
+    //      WARN(
+    //          index << ':' << swarIndex << ':' <<
+    //          (index % MD::NSlots) << ' ' <<
+    //          showMetadata(index, ex.md_.data()) <<
+    //          ' ' << hh << ' ' << indexHome
+    //      );
         };
         if(resultEndInMirror) {
             mirror[word] = 1;
@@ -173,11 +173,11 @@ TEST_CASE("Robin Hood", "[api][mapping][swar][robin-hood]") {
             ++findResult->value().second;
             REQUIRE(mirror[word] == findResult->value().second);
             showRecord(findResult);
-            WARN(word << ' ' << mirror[word]);
+    //      WARN(word << ' ' << mirror[word]);
         }
         ++wordIterator;
     }
-    WARN(mirror.size());
+ // WARN(mirror.size());
 }
 
 using FrontendSmall32 =

--- a/test/map/RobinHood.test.hybrid.cpp
+++ b/test/map/RobinHood.test.hybrid.cpp
@@ -26,12 +26,12 @@ bool intCheck(int n, int h) { return n == h; }
 using Robin =
     zoo::rh::RH_Frontend_WithSkarupkeTail<int, int, 16, 5, 3,
         std::hash<int>, std::equal_to<int>, u32>;
-using Straw = StrawmanMap<5, 3, u32>;
+using Straw = StrawmanMap<5, 3, u32, 16>;
 
 TEST_CASE("Robin Hood Metadata straw hybrid",
           "[api][mapping][swar][robin-hood]") {
     Robin rh;
-    Straw straw(16);
+    Straw straw;
 
     CHECK(straw.insert(5, &intCheck).first == 1);
     CHECK(straw.insert(7, &intCheck).first == 2);


### PR DESCRIPTION
Set up Scatter, RangeReduce and HashReduce functors so we can make uniform tables to compare against.
Extract findParametersBasic to construct hoisted hash and home index in a consistent way across tables.
Add straw test that uses the same hash,scatter,rangereduce,hashreduce as the basic robin hood table.