### PR TITLE
Fix build for Apple Clang

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 
 .vscode
 test/.vscode
+build
+.cache

--- a/test/inc/zoo/debug/rh/RobinHood.debug.h
+++ b/test/inc/zoo/debug/rh/RobinHood.debug.h
@@ -87,7 +87,8 @@ auto satisfiesInvariant(const Table &map, std::size_t begin = 0, std::size_t end
         for(auto n = Table::MD::NSlots; n--; ) {
             auto current = v.at(0);
             if(prior + 1 < current) {
-                return std::tuple(false, swarIndexBegin * Table::MD::NSlots + Table::MD::NSlots - n - 1);
+                std::size_t index = swarIndexBegin * Table::MD::NSlots + Table::MD::NSlots - n - 1;
+                return std::tuple(false, index);
             }
             v = v.shiftLanesRight(1);
             prior = current;

--- a/test/inc/zoo/debug/rh/RobinHood.debug.h
+++ b/test/inc/zoo/debug/rh/RobinHood.debug.h
@@ -1,8 +1,6 @@
 #ifndef ZOO_TEST_ROBINHOOD_DEBUGGING
 #define ZOO_TEST_ROBINHOOD_DEBUGGING
 
-#include "zoo/map/RobinHood.h"
-
 #include <sstream>
 #include <stdio.h>
 
@@ -24,8 +22,9 @@ auto display(
     constexpr auto HexPerHash = (MD::NBitsMost + 3) / 4;
 
     char format[60];
-    snprintf(format, 59, "%%0%dllx %%0%dllx %%0%dllx", HexPerSlot, HexPerSlot, HexPerPSL);
-    
+    const auto hexPerSlot = static_cast<int>(HexPerSlot);
+    snprintf(format, 59, "%%0%dllx %%0%dllx %%0%dllx", hexPerSlot, hexPerSlot, HexPerPSL);
+
     auto swarNdx = begin / MD::NSlots;
     auto swarEnd = end/MD::NSlots;
 
@@ -34,8 +33,9 @@ auto display(
     auto printLine =
         [&]() {
             char buffer[100];
-            sprintf(
+            snprintf(
                 buffer,
+                sizeof(buffer),
                 format,
                 initial.at(0), initial.hashes().at(0), initial.PSLs().at(0)
             );

--- a/test/inc/zoo/debug/rh/RobinHood.debug.h
+++ b/test/inc/zoo/debug/rh/RobinHood.debug.h
@@ -87,7 +87,7 @@ auto satisfiesInvariant(const Table &map, std::size_t begin = 0, std::size_t end
         for(auto n = Table::MD::NSlots; n--; ) {
             auto current = v.at(0);
             if(prior + 1 < current) {
-                std::size_t index = swarIndexBegin * Table::MD::NSlots + Table::MD::NSlots - n - 1;
+                const std::size_t index = swarIndexBegin * Table::MD::NSlots + Table::MD::NSlots - n - 1;
                 return std::tuple(false, index);
             }
             v = v.shiftLanesRight(1);

--- a/test/inc/zoo/variant.h
+++ b/test/inc/zoo/variant.h
@@ -3,7 +3,6 @@
 #include <tuple>
     // provides std::tuple_element to be able to index a pack of types,
     // indirectly includes type traits and utility
-#include <new>
 #include <zoo/meta/in_place_operations.h>
 #include <zoo/meta/traits.h>
 

--- a/test/map/RobinHood.test.cpp
+++ b/test/map/RobinHood.test.cpp
@@ -61,7 +61,8 @@ std::ostream &operator<<(std::ostream &out, V v) {
             if(v.intraIndex == ndx) {
                 ptr += snprintf(ptr, bufferSize, "<");
             }
-            ptr += snprintf(ptr, bufferSize, "%02lx", val & 0xFF);
+            const std::size_t va = val & 0xFF;
+            ptr += snprintf(ptr, bufferSize, "%02lx", va);
             if(v.intraIndex == ndx) {
                 ptr += snprintf(ptr, bufferSize, ">");
             }
@@ -143,7 +144,7 @@ TEST_CASE("Robin Hood", "[api][mapping][swar][robin-hood]") {
         }
         return true;
     };
-    
+
     std::regex words("\\w+");
     std::sregex_iterator
         wordsEnd{},
@@ -227,7 +228,7 @@ TEST_CASE("Robin Hood Metadata peek/poke u32 synthetic metadata basic",
     CHECK(std::tuple{0,0} == zoo::rh::impl::peek(table.md_, 0));
     CHECK(std::tuple{0,0} == zoo::rh::impl::peek(table.md_, 2));
 
-    // If we ask for a skarupke tail 
+    // If we ask for a skarupke tail
     FrontendSmall32::Backend be{table.md_.data()};
     auto [index, deadline, metadata] =
         be.findMisaligned_assumesSkarupkeTail(0x7, 1, [](int i) {return true;});
@@ -331,7 +332,7 @@ TEST_CASE("Robin Hood Metadata peek/poke u32 synthetic metadata psl one",
         CHECK(i+1 == missIndex);
         CHECK((missIndex)%4 ==
             FrontendSmall32::MD{missDeadline}.lsbIndex());
-        CHECK(0x02 == 
+        CHECK(0x02 ==
             missMetadata.at(FrontendSmall32::MD{missDeadline}.lsbIndex()));
     }
     {
@@ -375,7 +376,7 @@ TEST_CASE("Robin Hood Metadata peek/poke u32 synthetic metadata psl not one",
         CHECK(i-p+4 == missIndex);
         CHECK((missIndex)%4 ==
             FrontendSmall32::MD{missDeadline}.lsbIndex());
-        CHECK(0x04 == 
+        CHECK(0x04 ==
             missMetadata.at(FrontendSmall32::MD{missDeadline}.lsbIndex()));
     }
 }
@@ -449,7 +450,7 @@ TEST_CASE(
     m.data_ = MD35u32Ops::SSL{0x0401'8201};
     CHECK(0x0000'8001u == m.attemptMatch(SM{hash1}, SM{psl1}).value());
     CHECK(0x0000'8001u == SO35u32Ops::attemptMatch(m.data_, SM{hash1}, SM{psl1}).value());
-    } 
+    }
 }
 
 template<typename Container>
@@ -485,7 +486,7 @@ TEST_CASE("RH Validation") {
 
         while(corpus) {
             getline(corpus, line);
-            
+
             std::sregex_iterator
                 wordsEnd{},
                 wordIterator{line.begin(), line.end(), words};

--- a/test/map/RobinHood.test.cpp
+++ b/test/map/RobinHood.test.cpp
@@ -9,7 +9,6 @@
 #include <algorithm>
 #include <regex>
 #include <map>
-#include <sstream>
 #include <fstream>
 #include <unordered_map>
 
@@ -54,22 +53,23 @@ struct V {
 
 std::ostream &operator<<(std::ostream &out, V v) {
     char buffer[30];
+    const auto bufferSize = sizeof(buffer);
     char *ptr = buffer;
     auto val = v.v;
     auto printHalf = [&](auto low, auto high) {
         for(auto ndx = low; ndx < high; ++ndx) {
             if(v.intraIndex == ndx) {
-                ptr += sprintf(ptr, "<");
+                ptr += snprintf(ptr, bufferSize, "<");
             }
-            ptr += sprintf(ptr, "%02lx", val & 0xFF);
+            ptr += snprintf(ptr, bufferSize, "%02lx", val & 0xFF);
             if(v.intraIndex == ndx) {
-                ptr += sprintf(ptr, ">");
+                ptr += snprintf(ptr, bufferSize, ">");
             }
             val >>= 8;
         }
     };
     printHalf(0, 4);
-    ptr += sprintf(ptr, "'");
+    ptr += snprintf(ptr, bufferSize, "'");
     printHalf(4, 8);
     out << buffer;
     return out;


### PR DESCRIPTION
Had some type inference issues on Apple Clang, also cleaned up a few spots using `sprintf` as opposed to `snprintf`. 