### PR TITLE
ARM Strlen from Godbolt

### DIFF
--- a/benchmark/atoi-corpus.h
+++ b/benchmark/atoi-corpus.h
@@ -127,12 +127,21 @@ struct CorpusStringLength {
 #define AVX2_STRLEN_CORPUS_X_LIST /* nothing */
 #endif
 
+#if ZOO_CONFIGURED_TO_USE_NEON()
+#define NEON_STRLEN_CORPUS_X_LIST \
+    X(ZOO_NEON, zoo::neon_strlen)
+#else
+#define NEON_STRLEN_CORPUS_X_LIST /* nothing */
+#endif
+
+
 #define STRLEN_CORPUS_X_LIST \
     X(LIBC_STRLEN, strlen) \
     X(ZOO_STRLEN, zoo::c_strLength) \
     X(ZOO_NATURAL_STRLEN, zoo::c_strLength_natural) \
     X(GENERIC_GLIBC_STRLEN, STRLEN_old) \
-    AVX2_STRLEN_CORPUS_X_LIST
+    AVX2_STRLEN_CORPUS_X_LIST \
+    NEON_STRLEN_CORPUS_X_LIST
 
 #define X(Typename, FunctionToCall) \
     struct Invoke##Typename { int operator()(const char *p) { return FunctionToCall(p); } };

--- a/benchmark/atoi.h
+++ b/benchmark/atoi.h
@@ -18,6 +18,10 @@ std::size_t c_strLength_natural(const char *s);
 std::size_t avx2_strlen(const char* str);
 #endif
 
+#if ZOO_CONFIGURED_TO_USE_NEON()
+std::size_t neon_strlen(const char* str);
+#endif
+
 }
 
 std::size_t

--- a/inc/zoo/pp/platform.h
+++ b/inc/zoo/pp/platform.h
@@ -7,6 +7,12 @@
 #define ZOO_CONFIGURED_TO_USE_AVX() 0
 #endif
 
+#if (defined(__ARM_NEON) || defined(__ARM_NEON__)) && (defined(__aarch64__) || defined(_M_ARM64))
+#define ZOO_CONFIGURED_TO_USE_NEON() 1
+#else
+#define ZOO_CONFIGURED_TO_USE_NEON() 0
+#endif
+
 #ifdef _MSC_VER
 #define MSVC_EMPTY_BASES __declspec(empty_bases)
 #else


### PR DESCRIPTION
```
-------------------------------------------------------------------------------------------------------
Benchmark                                                             Time             CPU   Iterations
-------------------------------------------------------------------------------------------------------
runBenchmark<Corpus8DecimalDigits, InvokeLemire>                   1963 ns         1917 ns       365642
runBenchmark<Corpus8DecimalDigits, InvokeZoo>                      1953 ns         1916 ns       365751
runBenchmark<Corpus8DecimalDigits, InvokeLIBC>                     9521 ns         9344 ns        74932
runBenchmark<CorpusStringLength, InvokeLIBC_STRLEN>                4283 ns         4203 ns       164312
runBenchmark<CorpusStringLength, InvokeZOO_STRLEN>                 4472 ns         4388 ns       159545
runBenchmark<CorpusStringLength, InvokeZOO_NATURAL_STRLEN>         5009 ns         4911 ns       135583
runBenchmark<CorpusStringLength, InvokeGENERIC_GLIBC_STRLEN>       6802 ns         6681 ns       101432
runBenchmark<CorpusStringLength, InvokeZOO_NEON>                   3540 ns         3473 ns       206814
runBenchmark<CorpusStringLength, RepeatZooStrlen>                  4479 ns         4394 ns       158624
```