### PR TITLE
Implement GreaterLess with MSB on for SWAR.

### DIFF
--- a/inc/zoo/swar/SWAR.h
+++ b/inc/zoo/swar/SWAR.h
@@ -394,7 +394,7 @@ constexpr T
 indexOfMostSignficantLaneSet(SWAR<NBits, T> test) noexcept {
     const auto TypeWidth = sizeof(T) * 8;
     const auto TopVal = (T{1}<<(TypeWidth-NBits))-1, BottomVal = (T{1}<<(NBits-1))-1;
-    const u64 MappingConstant = TopVal / BottomVal;
+    const T MappingConstant = TopVal / BottomVal;
     return (test.value() * MappingConstant) >> (TypeWidth - NBits);
 }
 

--- a/inc/zoo/swar/SWAR.h
+++ b/inc/zoo/swar/SWAR.h
@@ -188,7 +188,7 @@ constexpr auto isolateLSB(T v) {
 
 template<int NBits, typename T>
 constexpr auto leastNBitsMask() {
-    return (T(1ull)<<NBits)-1;
+    return (T{1}<<NBits)-1;
 }
 
 template<int NBits, uint64_t T>
@@ -198,7 +198,7 @@ constexpr auto leastNBitsMask() {
 
 template<int NBits, typename T = uint64_t>
 constexpr T mostNBitsMask() {
-  return ~leastNBitsMask<sizeof(T)*8-NBits, T>();
+    return ~leastNBitsMask<sizeof(T)*8-NBits, T>();
 }
 
 
@@ -298,7 +298,7 @@ struct BooleanSWAR: SWAR<NBits, T> {
 
     template<int NB, typename TT>
     constexpr T
-    fastFirstLeftOn(SWAR<NBits, T> test) noexcept;
+    indexOfMostSignficantLaneSet(SWAR<NBits, T> test) noexcept;
 
     template<int NB, typename TT>
     friend constexpr BooleanSWAR<NB, TT>
@@ -367,7 +367,7 @@ constantIsGreaterEqual_MSB_off(SWAR<NBits, T> subtrahend) noexcept {
 
 template<typename T, typename U, typename V>
 constexpr T median(T x, U y, V z) {
-  return (x | y) & (y | z) & (x | z);
+    return (x | y) & (y | z) & (x | z);
 }
 
 template<int NBits, typename T>
@@ -386,16 +386,16 @@ greaterEqual(SWAR<NBits, T> left, SWAR<NBits, T> right) noexcept {
     return ~BooleanSWAR<NBits, T>{static_cast<T>(t)};  // ~(x<y) === x >= y
 }
 
-// In the condition where only MSBs will be on, we can fast lookup with 1 multiply the index of the leftmost byte.
+// In the condition where only MSBs will be on, we can fast lookup with 1 multiply the index of the most signficant byte that is on.
 // This appears to be a mapping from the (say) 256 unique values of a 64 bit int where only MSBs of each 8 bits can be on, but I don't fully understand it.
 // Adapted from TAOCP Vol 4A Page 153 Eq 94.
 template<int NBits, typename T>
 constexpr T
-fastFirstLeftOn(SWAR<NBits, T> test) noexcept {
-    const auto width = sizeof(T) * 8;
-    const auto tval = (1ull<<(width-NBits))-1, bval = (1ull<<(NBits-1))-1;
-    const u64 cval = tval / bval; 
-    return (test.value() * cval) >> (width - NBits);
+indexOfMostSignficantLaneSet(SWAR<NBits, T> test) noexcept {
+    const auto TypeWidth = sizeof(T) * 8;
+    const auto TopVal = (T{1}<<(TypeWidth-NBits))-1, BottomVal = (T{1}<<(NBits-1))-1;
+    const u64 MappingConstant = TopVal / BottomVal;
+    return (test.value() * MappingConstant) >> (TypeWidth - NBits);
 }
 
 template<int NBits, typename T>

--- a/inc/zoo/swar/SWAR.h
+++ b/inc/zoo/swar/SWAR.h
@@ -27,7 +27,6 @@ constexpr uint64_t popcount(uint64_t a) noexcept {
         >::execute(a);
 }
 
-
 /// Index into the bits of the type T that contains the MSB.
 template<typename T>
 constexpr std::make_unsigned_t<T> msbIndex(T v) noexcept {
@@ -298,6 +297,10 @@ struct BooleanSWAR: SWAR<NBits, T> {
     greaterEqual_MSB_off(SWAR<NB, TT>, SWAR<NB, TT>) noexcept;
 
     template<int NB, typename TT>
+    constexpr T
+    fastFirstLeftOn(SWAR<NBits, T> test) noexcept;
+
+    template<int NB, typename TT>
     friend constexpr BooleanSWAR<NB, TT>
     convertToBooleanSWAR(SWAR<NB, TT> arg) noexcept;
 };
@@ -360,6 +363,39 @@ constantIsGreaterEqual_MSB_off(SWAR<NBits, T> subtrahend) noexcept {
             minuendWithMSBs_turnedOn - subtrahendMSBs_turnedOff;
         return MSB_Mask & leastSignificantComparison;
     }
+}
+
+template<typename T, typename U, typename V>
+constexpr T median(T x, U y, V z) {
+  return (x | y) & (y | z) & (x | z);
+}
+
+template<int NBits, typename T>
+constexpr BooleanSWAR<NBits, T>
+greaterEqual(SWAR<NBits, T> left, SWAR<NBits, T> right) noexcept {
+    // Adapted from TAOCP V4 P152
+    // h is msbselector, x is right, l is lower/left.  Sets MSB to 1 in lanes
+    // in test variable t for when xi < yi for lane i . Invert for greaterEqual.
+    // t = h & ~<x~yz>
+    // z = (x|h) - (y&~h)
+    using S = swar::SWAR<NBits, T>;
+    const auto h = S::MostSignificantBit, x = left.value(), y = right.value();  // x=left, y= right is x < y
+    const auto z = (x|h) - (y&~h);
+    // bitwise ternary median! 
+    const auto t = h & ~median(x, ~y, z);
+    return ~BooleanSWAR<NBits, T>{static_cast<T>(t)};  // ~(x<y) === x >= y
+}
+
+// In the condition where only MSBs will be on, we can fast lookup with 1 multiply the index of the leftmost byte.
+// This appears to be a mapping from the (say) 256 unique values of a 64 bit int where only MSBs of each 8 bits can be on, but I don't fully understand it.
+// Adapted from TAOCP Vol 4A Page 153 Eq 94.
+template<int NBits, typename T>
+constexpr T
+fastFirstLeftOn(SWAR<NBits, T> test) noexcept {
+    const auto width = sizeof(T) * 8;
+    const auto tval = (1ull<<(width-NBits))-1, bval = (1ull<<(NBits-1))-1;
+    const u64 cval = tval / bval; 
+    return (test.value() * cval) >> (width - NBits);
 }
 
 template<int NBits, typename T>

--- a/test/swar/BasicOperations.cpp
+++ b/test/swar/BasicOperations.cpp
@@ -277,67 +277,80 @@ static_assert(0x80000000 == greaterEqual<7>(SWAR<4, uint32_t>(0x7654'3210)).valu
 */
 
 
-// Unusual formatting for easy visual verification.
 #define GE_MSB_TEST(left, right, result) static_assert(result == greaterEqual_MSB_off<4, u32>(SWAR<4, u32>(left), SWAR<4, u32>(right)).value());
 
-GE_MSB_TEST(0x1000'0010,
-            0x0111'1101,
-            0x8000'0080)
-GE_MSB_TEST(0x4333'3343,
-            0x4444'4444,
-            0x8000'0080)
-GE_MSB_TEST(0x0550'0110,
-            0x0110'0550,
-            0x8888'8008)
-GE_MSB_TEST(0x4771'1414,
-            0x4641'1774,
-            0x8888'8008)
+GE_MSB_TEST(
+    0x1000'0010,
+    0x0111'1101,
+    0x8000'0080)
+GE_MSB_TEST(
+    0x4333'3343,
+    0x4444'4444,
+    0x8000'0080)
+GE_MSB_TEST(
+    0x0550'0110,
+    0x0110'0550,
+    0x8888'8008)
+GE_MSB_TEST(
+    0x4771'1414,
+    0x4641'1774,
+    0x8888'8008)
+GE_MSB_TEST(
+    0x0123'4567,
+    0x0000'0000,
+    0x8888'8888)
+GE_MSB_TEST(
+    0x0123'4567,
+    0x7777'7777,
+    0x0000'0008)
+GE_MSB_TEST(
+    0x0000'0000,
+    0x0123'4567,
+    0x8000'0000)
+GE_MSB_TEST(
+    0x7777'7777,
+    0x0123'4567,
+    0x8888'8888)
 
-GE_MSB_TEST(0x0123'4567,
-            0x0000'0000,
-            0x8888'8888)
-GE_MSB_TEST(0x0123'4567,
-            0x7777'7777,
-            0x0000'0008)
-
-GE_MSB_TEST(0x0000'0000,
-            0x0123'4567,
-            0x8000'0000)
-GE_MSB_TEST(0x7777'7777,
-            0x0123'4567,
-            0x8888'8888)
-
-// Replicate the msb off tests with the lessthan that allows msb on
+// Replicate the msb off tests with the greaterEqual that allows msb on
 #define GE_MSB_ON_TEST(left, right, result) static_assert(result == greaterEqual<4, u32>(SWAR<4, u32>(left), SWAR<4, u32>(right)).value());
 
-GE_MSB_ON_TEST(0x1000'0010,
-               0x0111'1101,
-               0x8000'0080)
-GE_MSB_ON_TEST(0x4333'3343,
-               0x4444'4444,
-               0x8000'0080)
-GE_MSB_ON_TEST(0x0550'0110,
-               0x0110'0550,
-               0x8888'8008)
-GE_MSB_ON_TEST(0x4771'1414,
-               0x4641'1774,
-               0x8888'8008)
-GE_MSB_ON_TEST(0x0123'4567,
-               0x0000'0000,
-               0x8888'8888)
-GE_MSB_ON_TEST(0x0123'4567,
-               0x7777'7777,
-               0x0000'0008)
-GE_MSB_ON_TEST(0x0000'0000,
-               0x0123'4567,
-               0x8000'0000)
-GE_MSB_ON_TEST(0x7777'7777,
-               0x0123'4567,
-               0x8888'8888)
+GE_MSB_ON_TEST(
+    0x1000'0010,
+    0x0111'1101,
+    0x8000'0080)
+GE_MSB_ON_TEST(
+    0x4333'3343,
+    0x4444'4444,
+    0x8000'0080)
+GE_MSB_ON_TEST(
+    0x0550'0110,
+    0x0110'0550,
+    0x8888'8008)
+GE_MSB_ON_TEST(
+    0x4771'1414,
+    0x4641'1774,
+    0x8888'8008)
+GE_MSB_ON_TEST(
+    0x0123'4567,
+    0x0000'0000,
+    0x8888'8888)
+GE_MSB_ON_TEST(
+    0x0123'4567,
+    0x7777'7777,
+    0x0000'0008)
+GE_MSB_ON_TEST(
+    0x0000'0000,
+    0x0123'4567,
+    0x8000'0000)
+GE_MSB_ON_TEST(
+    0x7777'7777,
+    0x0123'4567,
+    0x8888'8888)
 
 TEST_CASE(
     "greaterEqualMSBOn",
-    "[swar][signed-swar][unsigned-swar]"
+    "[swar][unsigned-swar]"
 ) {
     SECTION("single") {
         for (uint32_t i = 1; i < 4; i++) {

--- a/test/swar/BasicOperations.cpp
+++ b/test/swar/BasicOperations.cpp
@@ -2,11 +2,18 @@
 
 #include "catch2/catch.hpp"
 
+#include <ios>
+#include <iomanip>
+#include <iostream>
 #include <type_traits>
 
 
 using namespace zoo;
 using namespace zoo::swar;
+
+using S2_64 = SWAR<2, uint64_t>;
+using S2_32 = SWAR<2, uint32_t>;
+using S2_16 = SWAR<2, uint16_t>;
 
 using S4_64 = SWAR<4, uint64_t>;
 using S4_32 = SWAR<4, uint32_t>;
@@ -260,8 +267,8 @@ static_assert(8 == lsbIndex(1<<8));
 static_assert(17 == lsbIndex(1<<17));
 static_assert(30 == lsbIndex(1<<30));
 
-/*
-These tests were not catching errors known to have been present
+
+/*These tests were not catching errors known to have been present
 static_assert(0x80880008 == greaterEqual<3>(SWAR<4, uint32_t>(0x3245'1027)).value());
 static_assert(0x88888888 == greaterEqual<0>(SWAR<4, uint32_t>(0x0123'4567)).value());
 static_assert(0x88888888 == greaterEqual<0>(SWAR<4, uint32_t>(0x7654'3210)).value());
@@ -269,8 +276,9 @@ static_assert(0x00000008 == greaterEqual<7>(SWAR<4, uint32_t>(0x0123'4567)).valu
 static_assert(0x80000000 == greaterEqual<7>(SWAR<4, uint32_t>(0x7654'3210)).value());
 */
 
+
 // Unusual formatting for easy visual verification.
-#define GE_MSB_TEST(left, right, result) static_assert(result== greaterEqual_MSB_off<4, u32>(SWAR<4, u32>(left), SWAR<4, u32>(right)).value());
+#define GE_MSB_TEST(left, right, result) static_assert(result == greaterEqual_MSB_off<4, u32>(SWAR<4, u32>(left), SWAR<4, u32>(right)).value());
 
 GE_MSB_TEST(0x1000'0010,
             0x0111'1101,
@@ -298,6 +306,64 @@ GE_MSB_TEST(0x0000'0000,
 GE_MSB_TEST(0x7777'7777,
             0x0123'4567,
             0x8888'8888)
+
+// Replicate the msb off tests with the lessthan that allows msb on
+#define GE_MSB_ON_TEST(left, right, result) static_assert(result == greaterEqual<4, u32>(SWAR<4, u32>(left), SWAR<4, u32>(right)).value());
+
+GE_MSB_ON_TEST(0x1000'0010,
+               0x0111'1101,
+               0x8000'0080)
+GE_MSB_ON_TEST(0x4333'3343,
+               0x4444'4444,
+               0x8000'0080)
+GE_MSB_ON_TEST(0x0550'0110,
+               0x0110'0550,
+               0x8888'8008)
+GE_MSB_ON_TEST(0x4771'1414,
+               0x4641'1774,
+               0x8888'8008)
+GE_MSB_ON_TEST(0x0123'4567,
+               0x0000'0000,
+               0x8888'8888)
+GE_MSB_ON_TEST(0x0123'4567,
+               0x7777'7777,
+               0x0000'0008)
+GE_MSB_ON_TEST(0x0000'0000,
+               0x0123'4567,
+               0x8000'0000)
+GE_MSB_ON_TEST(0x7777'7777,
+               0x0123'4567,
+               0x8888'8888)
+
+TEST_CASE(
+    "greaterEqualMSBOn",
+    "[swar][signed-swar][unsigned-swar]"
+) {
+    SECTION("single") {
+        for (uint32_t i = 1; i < 4; i++) {
+            const auto left = S2_16{0}.blitElement(1,  i);
+            const auto right = S2_16{S2_16::AllOnes}.blitElement(1, i-1);
+            const auto test = S2_16{0}.blitElement(1, 2);
+            CHECK(test.value() == greaterEqual<2, u16>(left, right).value()); 
+        }
+    }
+    SECTION("single") {
+        for (uint32_t i = 1; i < 15; i++) {
+            const auto large = S4_32{0}.blitElement(1,  i+1);
+            const auto small = S4_32{S4_32::AllOnes}.blitElement(1, i-1);
+            const auto test = S4_32{0}.blitElement(1, 8);
+            CHECK(test.value() == greaterEqual<4, u32>(large, small).value()); 
+        }
+    }
+    SECTION("allLanes") {
+        for (uint32_t i = 1; i < 15; i++) {
+            const auto small = S4_32(S4_32::LeastSignificantBit * (i-1));
+            const auto large = S4_32(S4_32::LeastSignificantBit * (i+1));
+            const auto test = S4_32(S4_32::LeastSignificantBit * 8);
+            CHECK(test.value() == greaterEqual<4, u32>(large, small).value()); 
+        }
+    }
+}
 
 static_assert(0x123 == SWAR<4, uint32_t>(0x173).blitElement(1, 2).value());
 static_assert(0 == isolateLSB(u32(0)));


### PR DESCRIPTION
Includes testing that exercises MSB on and various call patterns. Could be stronger.

TAOCP claims the formula used takes 8 ops.