### PR TITLE
Implementation of atol using SWAR of 128 bits

### DIFF
--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -21,8 +21,8 @@ macro(set_xcode_properties TARGET_NAME)
         set_target_properties(${TARGET_NAME} PROPERTIES
             XCODE_ATTRIBUTE_ENABLE_AVX YES
             XCODE_ATTRIBUTE_ENABLE_AVX2 YES
-            XCODE_ATTRIBUTE_OTHER_CPLUSPLUSFLAGS "-mavx -mavx2"
-            XCODE_ATTRIBUTE_OTHER_CFLAGS "-mavx -mavx2"
+            XCODE_ATTRIBUTE_OTHER_CPLUSPLUSFLAGS "-mavx -mavx2 -mbmi2"
+            XCODE_ATTRIBUTE_OTHER_CFLAGS "-mavx -mavx2 -mbmi2"
         )
     endif()
 endmacro()
@@ -44,7 +44,7 @@ add_subdirectory(dependencies/google_benchmark)
 add_executable(
   catch2Benchmark
     catch2BenchmarkMain.cpp catch2Functions.cpp catch2swar-demo.cpp
-    atoi.cpp
+    atoi.cpp atoi-catch2-tests.cpp
     egyptian.cpp
     # RobinHood.benchmark.cpp
 )

--- a/benchmark/atoi-catch2-tests.cpp
+++ b/benchmark/atoi-catch2-tests.cpp
@@ -3,9 +3,19 @@
 #include "zoo/swar/SWAR.h"
 
 uint64_t calculateBase10(zoo::swar::SWAR<8, __uint128_t>) noexcept;
+namespace zoo {
+int64_t c_strToL(const char *str) noexcept;
+}
+
+template<int RequiredAlignment>
+void requireAlignment(const void *p) {
+    std::uintptr_t asNumber = reinterpret_cast<std::uintptr_t>(p);
+    REQUIRE(asNumber % RequiredAlignment == 0);
+}
 
 TEST_CASE("Calculate Base10", "[pure-test][swar][atoi]") {
-    alignas(16) auto inputString = "1234567898765432";
+    alignas(16) char inputString[] = "1234567898765432";
+    requireAlignment<16>(inputString);
     using S = zoo::swar::SWAR<8, __uint128_t>;
     S input;
     memcpy(&input.m_v, inputString, 16);
@@ -15,4 +25,29 @@ TEST_CASE("Calculate Base10", "[pure-test][swar][atoi]") {
     constexpr auto expected = __int128_t(12345678) * 100'000'000 + 98765432;
     auto calculated = calculateBase10(input);
     REQUIRE(expected == calculated);
+}
+
+TEST_CASE("Atol", "[pure-test][swar][atoi]") {
+    // Because of the code sharing between the implementation of atoi and atol,
+    // and because atoi has been thoroughly tested in the benchmarking,
+    // there isn't much to test of atol, other than being able to deal with
+    // numbers higher than representable with an integer and 16-byte
+    // misalignment.
+    alignas(16) char inputString[] = "0123456789-\f9123456789987654321";
+    // notice 91...99...1 is very close to 2^63 - 1, max for 64 signed
+    // log2(9123456789987654321) ~= 62.984
+    requireAlignment<16>(inputString);
+    // Notice the second number, 91...99...1 is misaligned by 12 bytes
+    SECTION("Aligned atol") {
+        auto expected = 123456789;
+        auto converted = zoo::c_strToL(inputString);
+        REQUIRE(converted == expected);
+    }
+    SECTION("Misaligned atol") {
+        auto expected = 9123456789987654321ll;
+        auto secondNumber = inputString + 11;
+        REQUIRE(std::string("\f9123456789987654321") == secondNumber);
+        auto converted = zoo::c_strToL(secondNumber);
+        REQUIRE(converted == expected);
+    }
 }

--- a/benchmark/atoi-catch2-tests.cpp
+++ b/benchmark/atoi-catch2-tests.cpp
@@ -1,0 +1,18 @@
+#include "catch2/catch.hpp"
+
+#include "zoo/swar/SWAR.h"
+
+uint64_t calculateBase10(zoo::swar::SWAR<8, __uint128_t>) noexcept;
+
+TEST_CASE("Calculate Base10", "[pure-test][swar][atoi]") {
+    alignas(16) auto inputString = "1234567898765432";
+    using S = zoo::swar::SWAR<8, __uint128_t>;
+    S input;
+    memcpy(&input.m_v, inputString, 16);
+    constexpr S CharZeros{zoo::meta::BitmaskMaker<__uint128_t, '0', 8>::value};
+    input = input - CharZeros;
+
+    constexpr auto expected = __int128_t(12345678) * 100'000'000 + 98765432;
+    auto calculated = calculateBase10(input);
+    REQUIRE(expected == calculated);
+}

--- a/benchmark/atoi-corpus.h
+++ b/benchmark/atoi-corpus.h
@@ -267,7 +267,9 @@ struct CorpusAtoi {
             }
             int number = exp(logBase10 * M_LN10);
             auto n = sprintf(conversionBuffer, "%d%c", number, postNumber(generator));
-            if(n < 0) { throw 0; }
+            if(n < 0) {
+                throw 0;
+            }
             allCharacters.append(conversionBuffer);
             sizes.push_back(count + negativeSign + iz + n);
             consumeStrPtr(allCharacters.c_str() + currentLength, count + negativeSign + iz + n);
@@ -302,7 +304,9 @@ struct CorpusAtoi {
 };
 
 #define ATOI_CORPUS_X_LIST \
-    X(GLIBC_atoi, atoi) X(ZOO_ATOI, zoo::c_strToI) X(COMPARE_ATOI, zoo::compareAtoi)
+    X(GLIBC_atoi, atoi) X(ZOO_ATOI, zoo::c_strToI)\
+    X(COMPARE_ATOI, zoo::compareAtoi) \
+    X(COMPARE_ATOL, zoo::compareAtol)
 
 #define X(Typename, FunctionToCall) \
     struct Invoke##Typename { int operator()(const char *p) { return FunctionToCall(p); } };

--- a/benchmark/atoi.cpp
+++ b/benchmark/atoi.cpp
@@ -57,10 +57,12 @@ uint32_t calculateBase10(zoo::swar::SWAR<8, uint64_t> convertedToIntegers) noexc
 uint64_t calculateBase10(zoo::swar::SWAR<8, __uint128_t> convertedToIntegers) noexcept {
     auto by11base256 = convertedToIntegers.multiply(256*10 + 1);
     auto bytePairs = zoo::swar::doublePrecision(by11base256).odd;
-    //static_assert(std::is_same_v<decltype(bytePairs), zoo::swar::SWAR<16, uint64_t>>);
     auto by101base2to16 = bytePairs.multiply(1 + (100 << 16));
     auto byteQuads = zoo::swar::doublePrecision(by101base2to16).odd;
     auto by10001base2to32 = byteQuads.multiply(1 + (10000ull << 32));
+    // Now, truly work with 128 bits: combine two 32 bit results, each
+    // corresponding to 8 bytes of inputs, into the the 64 bit result by
+    // scaling one by 10^8
     auto byteOcts = zoo::swar::doublePrecision(by10001base2to32).odd;
     auto byHundredMillionBase2to64 =
         byteOcts.multiply(1 + (__uint128_t(100'000'000) << 64));

--- a/benchmark/atoi.h
+++ b/benchmark/atoi.h
@@ -18,12 +18,23 @@ std::size_t leadingSpacesCount(const char *) noexcept;
 std::size_t c_strLength(const char *s);
 std::size_t c_strLength_natural(const char *s);
 int32_t c_strToI(const char *) noexcept;
+int64_t c_strToL(const char *) noexcept;
 
 inline int compareAtoi(const char *s) {
     auto
         from_stdlib = atoi(s),
         from_zoo = c_strToI(s);
     if(from_stdlib != from_zoo) { throw 0; }
+    return from_stdlib;
+}
+
+inline int compareAtol(const char *s) {
+    auto
+        from_stdlib = atoll(s),
+        from_zoo = c_strToL(s);
+    if(from_stdlib != from_zoo) {
+        auto recalc = c_strToL(s);
+        throw 0; }
     return from_stdlib;
 }
 

--- a/benchmark/atoi_impl.h
+++ b/benchmark/atoi_impl.h
@@ -1,0 +1,35 @@
+#include "zoo/swar/SWAR.h"
+
+#include <tuple>
+#include <string.h>
+
+uint64_t calculateBase10(
+    zoo::swar::SWAR<8, __uint128_t> convertedToIntegers
+) noexcept;
+
+uint32_t calculateBase10(
+    zoo::swar::SWAR<8, uint64_t> convertedToIntegers
+) noexcept;
+
+namespace zoo {
+
+/// @brief Loads the "block" containing the pointer, by proper alignment
+/// @tparam PtrT Pointer type for loading
+/// @tparam Block as the name indicates
+/// @param pointerInsideBlock the potentially misaligned pointer
+/// @param b where the loaded bytes will be put
+/// @return a pair to indicate the aligned pointer to the base of the block
+/// and the misalignment, in bytes, of the source pointer
+template<typename PtrT, typename Block>
+std::tuple<PtrT *, int>
+blockAlignedLoad(PtrT *pointerInsideBlock, Block *b) {
+    uintptr_t asUint = reinterpret_cast<uintptr_t>(pointerInsideBlock);
+    constexpr auto Alignment = alignof(Block), Size = sizeof(Block);
+    static_assert(Alignment == Size);
+    auto misalignment = asUint % Alignment;
+    auto *base = reinterpret_cast<PtrT *>(asUint - misalignment);
+    memcpy(b, base, Size);
+    return { base, misalignment };
+}
+
+}

--- a/benchmark/atoi_impl.h
+++ b/benchmark/atoi_impl.h
@@ -20,6 +20,7 @@ namespace zoo {
 /// @param b where the loaded bytes will be put
 /// @return a pair to indicate the aligned pointer to the base of the block
 /// and the misalignment, in bytes, of the source pointer
+/// \note The misalignment is in the range [ 0, sizeof(Block) [
 template<typename PtrT, typename Block>
 std::tuple<PtrT *, int>
 blockAlignedLoad(PtrT *pointerInsideBlock, Block *b) {

--- a/benchmark/catch2swar-demo.cpp
+++ b/benchmark/catch2swar-demo.cpp
@@ -106,7 +106,7 @@ TEST_CASE("Atoi benchmarks", "[atoi][swar]") {
     #undef X
 }
 
-TEST_CASE("Atoi correctness", "[swar][atoi]") {
+TEST_CASE("Atoi correctness", "[pure-test][swar][atoi]") {
     auto empty = "";
     REQUIRE(0 == zoo::c_strToI(empty));
     alignas(8) constexpr char EmptyMisaligned[8] = { 'Q', '\0', '0', '1', '2', '3', '9', '\0' };


### PR DESCRIPTION
This is the first time we apply `SWAR` to a base type of 128 bits.  There are many inefficiencies about using `__uint128_t` for the base type of `SWAR`s, since that form of 128 bit integers is emulated by the compiler using two 64 bit values.

This PR concerns itself with bare-minimum support of 128 bits, which only required modifying the operation of counting trailing zeros, to apply it to our string benchmarks to have a performance idea.

The changes introduced are worthy of being upgraded to "master", but they are not consistent with full support of `SWAR` of 128 bit base.