### PR TITLE
First pass of encoding 'find first zero byte of a string' as a generic operation in zoo SWAR. Also updates equals() to be cheaper and tested.

### DIFF
--- a/benchmark/atoi.cpp
+++ b/benchmark/atoi.cpp
@@ -305,6 +305,8 @@ std::size_t c_strLength(const char *s) {
         // subtracting one (if their value is greater than 0x80).
         // This provides a way to detect the first null: It is the first lane
         // in firstNullTurnsOnMSB that "flipped on" its MSB
+        // According to The Art of Computer Programming, Knuth 4A pg 152,
+        // credit due to Alan Mycroft
         auto cheapestInversionOfMSBs = ~bytes;
         auto firstMSBsOnIsFirstNull =
             firstNullTurnsOnMSB & cheapestInversionOfMSBs;


### PR DESCRIPTION
The description of 'leftmost' and 'rightmost' byte gets very confusing with little or big endian representations.

Also swaps the impl of equals/differents with the `h&~(x|((x|h)-l))` where `x = l^r` construction from TAOCP, which passes tests.