### PR TITLE
Fix integer promotion caused edge with blitElement(), at(), and more!

### DIFF
--- a/test/map/RobinHood.test.cpp
+++ b/test/map/RobinHood.test.cpp
@@ -86,7 +86,6 @@ auto showMetadata(std::size_t index, MD *md) {
 //WARN(__VA_ARGS__)
 
 using SMap = zoo::rh::RH_Frontend_WithSkarupkeTail<std::string, int, 255, 5, 3>;
-
 auto valueInvoker(void *p, std::size_t index) {
     return static_cast<SMap *>(p)->values_[index].value();
 }

--- a/test/swar/BasicOperations.cpp
+++ b/test/swar/BasicOperations.cpp
@@ -349,23 +349,49 @@ static_assert(0xF000'0000ul == mostNBitsMask<4, u32>());
 static_assert(0xF800'0000ul == mostNBitsMask<5, u32>());
 static_assert(0xFC00'0000ul == mostNBitsMask<6, u32>());
 
+
+
 static_assert(0x01u == leastNBitsMask<1, u8>());
 static_assert(0x03u == leastNBitsMask<2, u8>());
 static_assert(0x07u == leastNBitsMask<3, u8>());
 static_assert(0x0Fu == leastNBitsMask<4, u8>());
 static_assert(0x1Fu == leastNBitsMask<5, u8>());
+static_assert(0x3Fu == leastNBitsMask<6, u8>());
+static_assert(0x7Fu == leastNBitsMask<7, u8>());
+static_assert(0xFFu == leastNBitsMask<8, u8>());
 
-static_assert(0x0000'01ul == leastNBitsMask<1, u32>());
-static_assert(0x0000'03ul == leastNBitsMask<2, u32>());
-static_assert(0x0000'07ul == leastNBitsMask<3, u32>());
-static_assert(0x0000'0Ful == leastNBitsMask<4, u32>());
-static_assert(0x0000'1Ful == leastNBitsMask<5, u32>());
+static_assert(0x0001u == leastNBitsMask<1, u16>());
+static_assert(0x0003u == leastNBitsMask<2, u16>());
+static_assert(0x0007u == leastNBitsMask<3, u16>());
+static_assert(0x000Fu == leastNBitsMask<4, u16>());
+static_assert(0x001Fu == leastNBitsMask<5, u16>());
+static_assert(0x003Fu == leastNBitsMask<6, u16>());
+static_assert(0x007Fu == leastNBitsMask<7, u16>());
+static_assert(0x00FFu == leastNBitsMask<8, u16>());
+static_assert(0x01FFu == leastNBitsMask<9, u16>());
+static_assert(0x03FFu == leastNBitsMask<10, u16>());
+static_assert(0x07FFu == leastNBitsMask<11, u16>());
+static_assert(0x0FFFu == leastNBitsMask<12, u16>());
+static_assert(0x1FFFu == leastNBitsMask<13, u16>());
+static_assert(0x3FFFu == leastNBitsMask<14, u16>());
+static_assert(0x7FFFu == leastNBitsMask<15, u16>());
+static_assert(0xFFFFu == leastNBitsMask<16, u16>());
+
+static_assert(0x0000'0001ul == leastNBitsMask<1, u32>());
+static_assert(0x0000'0003ul == leastNBitsMask<2, u32>());
+static_assert(0x0000'0007ul == leastNBitsMask<3, u32>());
+static_assert(0x0000'000Ful == leastNBitsMask<4, u32>());
+static_assert(0x0000'001Ful == leastNBitsMask<5, u32>());
+static_assert(0x7FFF'FFFFul == leastNBitsMask<31, u32>());
+static_assert(0xFFFF'FFFFul == leastNBitsMask<32, u32>());
 
 static_assert(0x01ull == leastNBitsMask<1, u64>());
 static_assert(0x03ull == leastNBitsMask<2, u64>());
 static_assert(0x07ull == leastNBitsMask<3, u64>());
 static_assert(0x0Full == leastNBitsMask<4, u64>());
 static_assert(0x1Full == leastNBitsMask<5, u64>());
+static_assert(0x7FFF'FFFF'FFFF'FFFFull == leastNBitsMask<63, u64>());
+static_assert(0xFFFF'FFFF'FFFF'FFFFull == leastNBitsMask<64, u64>());
 
 static_assert(0xB == isolate<4>(0x1337'BDBC'2448'ACABull));
 static_assert(0xAB == isolate<8>(0x1337'BDBC'2448'ACABull));
@@ -413,6 +439,18 @@ static_assert(5 == lsbIndex(1<<5));
 static_assert(8 == lsbIndex(1<<8));
 static_assert(17 == lsbIndex(1<<17));
 static_assert(30 == lsbIndex(1<<30));
+
+static_assert(S3_16{Literals<3,u16>, {5,4,3,2,5}}.value() == S3_16{Literals<3,u16>, {5,4,3,2,1}}.blitElement(0, 5).value());
+static_assert(S3_16{Literals<3,u16>, {5,4,3,5,1}}.value() == S3_16{Literals<3,u16>, {5,4,3,2,1}}.blitElement(1, 5).value());
+static_assert(S3_16{Literals<3,u16>, {5,4,5,2,1}}.value() == S3_16{Literals<3,u16>, {5,4,3,2,1}}.blitElement(2, 5).value());
+static_assert(S3_16{Literals<3,u16>, {5,1,3,2,1}}.value() == S3_16{Literals<3,u16>, {5,4,3,2,1}}.blitElement(3, 1).value());
+static_assert(S3_16{Literals<3,u16>, {1,4,3,2,1}}.value() == S3_16{Literals<3,u16>, {5,4,3,2,1}}.blitElement(4, 1).value());
+
+static_assert(1 == S3_16{Literals<3,u16>, {5,4,3,2,1}}.at(0));
+static_assert(2 == S3_16{Literals<3,u16>, {5,4,3,2,1}}.at(1));
+static_assert(3 == S3_16{Literals<3,u16>, {5,4,3,2,1}}.at(2));
+static_assert(4 == S3_16{Literals<3,u16>, {5,4,3,2,1}}.at(3));
+static_assert(5 == S3_16{Literals<3,u16>, {5,4,3,2,1}}.at(4));
 
 #define GE_MSB_TEST(left, right, result) static_assert(result == greaterEqual_MSB_off<4, u32>(SWAR<4, u32>(left), SWAR<4, u32>(right)).value());
 


### PR DESCRIPTION
Fixes leastNBitsMask, blitElement, at and more for various usage conditions. Turns out integer promotion causes things to work in a complicated way when using the same code to mess with integers of different widths.  The implemented solution feels a little hacky, but it fixes the immediate errors (and probably ones we didn't even notice). Previously, a variety of hard to predict failures would happen when using NBits counts in various constructs at 0 and sizebits(T).

The explanation is a couple fold, and at least both of these things combined with attempts to have code that handles 8,16,32 and 64 bit has resulted in various compile errors and bugs showing up over time.

Attempting to apply bitwise complement to a zero value of unsigned 8 or 16 bit integers results in pre-conversion of the 0 init unsigned value to a signed 32 bit int value.  After conversion, this becomes a -1 (and stays signed int32).

This is then given to left or right shift, causing the failure we've seen of "cannot shift a negative number".

Attempting to use ~T{1}
Given any right or left shift of any all-ones unsigned integer type T that is subject to integer promotion to signed int32 before arithmetic (including << and >> ), the following
```
(~T{0})<< any_bitcount)
(~T{0})>> any_bitcount)
```
will always result in a left operand that is negative (and thus invalid).

As an example of why "shift left 8 on u8 or 16 on u16" "works", see integer promotion explanation above.
u16{1} << 16 behaves as expected when _actually_ shifting a signed int32.  As does u16{1} << 17!!
```
src/zoo/test/swar/BasicOperations.cpp:206: FAILED:
  CHECK( 0x01u == (u16{1}<<16) )
with expansion:
  1 == 65536 (0x10000)

src/zoo/test/swar/BasicOperations.cpp:207: FAILED:
  CHECK( 0x01u == (u16{1}<<17) )
with expansion:
  1 == 131072 (0x20000)  // 17 shift on a 16 bit type worked just fine! Promotion!

src/zoo/test/swar/BasicOperations.cpp:208: FAILED:
  CHECK( 0x01u == (u16{1}<<16) -1 )
with expansion:
  1 == 65535 (0xffff)
```

(see https://en.cppreference.com/w/c/language/conversion 'Integer promotions')
to wit:
"""Note: integer promotions are applied only

as part of usual arithmetic conversions (see above)
as part of default argument promotions (see above)
to the operand of the unary arithmetic operators + and -
to the operand of the unary bitwise operator ~
to both operands of the shift operators << and >>"""

