### PR TITLE
Update Parallel Suffix 

### DIFF
--- a/inc/zoo/swar/associative_iteration.h
+++ b/inc/zoo/swar/associative_iteration.h
@@ -41,51 +41,23 @@ std::ostream &operator<<(std::ostream &out, zoo::swar::SWAR<NB, B> s) {
 
 namespace zoo::swar {
 
-/// \note This code should be substituted by an application of "progressive" algebraic iteration
-/// \note There is also parallelPrefix (to be implemented)
-template<int NB, typename B>
-constexpr SWAR<NB, B> parallelSuffix(SWAR<NB, B> input) {
-    using S = SWAR<NB, B>;
+template<typename S>
+constexpr auto parallelSuffix(S input) {
     auto
-        shiftClearingMask = S{static_cast<B>(~S::MostSignificantBit)},
-        doubling = input,
-        result = S{0};
-    auto
-        bitsToXOR = NB,
+        log2Count = meta::logCeiling(S::NBits),
         power = 1;
 
-    #define ZTE(...)
-        // ZOO_TRACEABLE_EXPRESSION(__VA_ARGS__)
-    for(;;) {
-        ZTE(doubling);
-        // From the perspective of "associative iteration", this is when we ask whether to "add"
-        if(1 & bitsToXOR) {
-            ZTE(result ^ doubling);
-            result = result ^ doubling;
-            ZTE(doubling.shiftIntraLaneLeft(power, shiftClearingMask));
-            doubling = doubling.shiftIntraLaneLeft(power, shiftClearingMask);
-        }
-        ZTE(bitsToXOR >> 1);
-        bitsToXOR >>= 1;
-        if(!bitsToXOR) { break; }
-        auto shifted = doubling.shiftIntraLaneLeft(power, shiftClearingMask);
-        ZTE(shifted);
-        ZTE(doubling ^ shifted);
-        // This is part of the "doubling" step in A. I.
-        // Doubling has several parts, though, the shifting, masking and XOR
-        doubling = doubling ^ shifted;
-        // 01...1
-        // 001...1
-        // 00001...1
-        // 000000001...1
-        shiftClearingMask =
-            shiftClearingMask &
-                S{static_cast<B>(shiftClearingMask.value() >> power)};
-        ZTE(power << 1);
+    auto
+        result = input,
+        shiftMask = S{~S::MostSignificantBit};
+
+    for (;;) {
+        result = result ^ result.shiftIntraLaneLeft(power, shiftMask);
+        if (!--log2Count) { break; }
+        shiftMask = shiftMask & S{shiftMask.value() >> power};
         power <<= 1;
     }
-    ZTE(input);
-    #undef ZTE
+
     return S{result};
 }
 

--- a/junkyard/inc/junk/compressionWithOldParallelSuffix.h
+++ b/junkyard/inc/junk/compressionWithOldParallelSuffix.h
@@ -1,0 +1,108 @@
+
+#include <zoo/swar/SWAR.h>
+
+namespace zoo::swar::junk {
+
+template <int NB, typename B>
+constexpr SWAR<NB, B> old_parallelSuffix(SWAR<NB, B> input) {
+  using S = SWAR<NB, B>;
+  auto shiftClearingMask = S{static_cast<B>(~S::MostSignificantBit)},
+       doubling = input, result = S{0};
+  auto bitsToXOR = NB, power = 1;
+
+#define ZTE(...)
+  // ZOO_TRACEABLE_EXPRESSION(__VA_ARGS__)
+  for (;;) {
+    ZTE(doubling);
+    if (1 & bitsToXOR) {
+      ZTE(result ^ doubling);
+      result = result ^ doubling;
+      ZTE(doubling.shiftIntraLaneLeft(power, shiftClearingMask));
+      doubling = doubling.shiftIntraLaneLeft(power, shiftClearingMask);
+    }
+    ZTE(bitsToXOR >> 1);
+    bitsToXOR >>= 1;
+    if (!bitsToXOR) {
+      break;
+    }
+    auto shifted = doubling.shiftIntraLaneLeft(power, shiftClearingMask);
+    ZTE(shifted);
+    ZTE(doubling ^ shifted);
+    doubling = doubling ^ shifted;
+    // 01...1
+    // 001...1
+    // 00001...1
+    // 000000001...1
+    shiftClearingMask = shiftClearingMask &
+                        S{static_cast<B>(shiftClearingMask.value() >> power)};
+    ZTE(power << 1);
+    power <<= 1;
+  }
+  ZTE(input);
+#undef ZTE
+  return S{result};
+}
+
+#define parallelSuffix old_parallelSuffix
+template <int NB, typename B>
+constexpr SWAR<NB, B>
+compressWithOldParallelSuffix(SWAR<NB, B> input, SWAR<NB, B> compressionMask) {
+// This solution uses the parallel suffix operation as a primary tool:
+// For every bit postion it indicates an odd number of ones to the right,
+// including itself.
+// Because we want to detect the "oddness" of groups of zeroes to the right,
+// we flip the compression mask.  To not count the bit position itself,
+// we shift by one.
+#define ZTE(...)
+  // ZOO_TRACEABLE_EXPRESSION(__VA_ARGS__)
+  ZTE(input);
+  ZTE(compressionMask);
+  using S = SWAR<NB, B>;
+  auto result = input & compressionMask;
+  auto groupSize = 1;
+  auto shiftLeftMask = S{S::LowerBits}, shiftRightMask = S{S::LowerBits << 1};
+  ZTE(~compressionMask);
+  auto forParallelSuffix = // this is called "mk" in the book
+      (~compressionMask).shiftIntraLaneLeft(groupSize, shiftLeftMask);
+  ZTE(forParallelSuffix);
+  // note: forParallelSuffix denotes positions with a zero
+  // immediately to the right in 'compressionMask'
+  for (;;) {
+    ZTE(groupSize);
+    ZTE(shiftLeftMask);
+    ZTE(shiftRightMask);
+    ZTE(result);
+    auto oddCountOfGroupsOfZerosToTheRight = // called "mp" in the book
+        parallelSuffix(forParallelSuffix);
+    ZTE(oddCountOfGroupsOfZerosToTheRight);
+    // compress the bits just identified in both the result and the mask
+    auto moving = compressionMask & oddCountOfGroupsOfZerosToTheRight;
+    ZTE(moving);
+    compressionMask = (compressionMask ^ moving) | // clear the moving
+                      moving.shiftIntraLaneRight(groupSize, shiftRightMask);
+    ZTE(compressionMask);
+    auto movingFromInput = result & moving;
+    result = (result ^ movingFromInput) | // clear the moving from the result
+             movingFromInput.shiftIntraLaneRight(groupSize, shiftRightMask);
+    auto nextGroupSize = groupSize << 1;
+    if (NB <= nextGroupSize) {
+      break;
+    }
+    auto evenCountOfGroupsOfZerosToTheRight =
+        ~oddCountOfGroupsOfZerosToTheRight;
+    forParallelSuffix = forParallelSuffix & evenCountOfGroupsOfZerosToTheRight;
+    auto newShiftLeftMask =
+        shiftLeftMask.shiftIntraLaneRight(groupSize, shiftRightMask);
+    shiftRightMask =
+        shiftRightMask.shiftIntraLaneLeft(groupSize, shiftLeftMask);
+    shiftLeftMask = newShiftLeftMask;
+    groupSize = nextGroupSize;
+  }
+  ZTE(result);
+#undef ZTE
+  return result;
+}
+#undef parallelSuffix
+
+} // namespace zoo::swar::junk
+


### PR DESCRIPTION

```
----------------------------------------------------------------------------------------------
Benchmark                                                    Time             CPU   Iterations
----------------------------------------------------------------------------------------------
runCompressions<4, UseSWAR>                               1318 ns         1291 ns       541838
runCompressions<4, UseOldParallelSuffix>                  7044 ns         6934 ns       100607
runCompressions<4, CompareNewAndOldParallelSuffix>        8651 ns         8514 ns        82220
runCompressions<8, UseSWAR>                               7271 ns         7149 ns        96997
runCompressions<8, UseOldParallelSuffix>                 15037 ns        14796 ns        47364
runCompressions<8, CompareNewAndOldParallelSuffix>       20979 ns        20657 ns        33887
runCompressions<16, UseSWAR>                             12322 ns        12126 ns        57702
runCompressions<16, UseOldParallelSuffix>                27133 ns        26641 ns        26617
runCompressions<16, CompareNewAndOldParallelSuffix>      37861 ns        37270 ns        18767
runCompressions<32, UseSWAR>                             19148 ns        18784 ns        37240
runCompressions<32, UseOldParallelSuffix>                44419 ns        43650 ns        15744
runCompressions<32, CompareNewAndOldParallelSuffix>      62413 ns        61247 ns        11397
runCompressions<64, UseSWAR>                             26320 ns        25932 ns        27007
runCompressions<64, UseOldParallelSuffix>                67408 ns        66484 ns        10566
runCompressions<64, CompareNewAndOldParallelSuffix>      91202 ns        89833 ns         7829
```